### PR TITLE
Define of  SDcard device path as command line parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ usage:
 	@echo "RaspberryMatic Build Environment (RBE) Version ${RBE_VERSION}"
 	@echo "Usage:"
 	@echo "	make dist: install buildroot and create default RaspberryMatic Image"
+	@echo "	make install of=/dev/sdX: write image to SD card under /dev/sdX"
 	@echo "	make distclean: clean everything"
 
 buildroot-$(BUILDROOT_VERSION).tar.bz2:
@@ -49,7 +50,7 @@ umount:
 	sudo kpartx -dv build-$(BOARD)/images/sdcard.img
 
 install:
-	sudo dd if=build-$(BOARD)/images/sdcard.img of=/dev/sdc bs=4096
+	sudo -- /bin/sh -c 'dd if=build-$(BOARD)/images/sdcard.img of=$(of) bs=4096 && sync'
 
 menuconfig: buildroot-$(BUILDROOT_VERSION) build-$(BOARD)
 	cd build-$(BOARD) && make O=`pwd` -C ../buildroot-$(BUILDROOT_VERSION) BR2_EXTERNAL=../buildroot-external menuconfig

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ git clone https://github.com/jens-maus/RaspberryMatic
 $ cd RaspberryMatic
 $ make dist
 [wait up to 1h]
-$ sudo dd if=build-raspmatic_rpi/images/sdcard.img of=/dev/sdX bs=4096
+$ make install of=/dev/sdX
 ```
 
 ### Using the generated cross compiler


### PR DESCRIPTION
I changed command "make install" to define SDcard device path via command line and added "sync" command to flush the write buffer.
Write image do card is done using "make install of=/dev/sdX".

Developed and tested unter CentOS 7.3