### PR TITLE
fixed DS1307/DS3231 initialization

### DIFF
--- a/buildroot-external/overlay/base/etc/init.d/S00eQ3SystemStart
+++ b/buildroot-external/overlay/base/etc/init.d/S00eQ3SystemStart
@@ -173,11 +173,13 @@ init_rtc_device() {
   if [[ $? -eq 0 ]]; then
     # check for DS3231
     modprobe i2c:ds3231
+    echo ds3231 0x68 >/sys/class/i2c-adapter/i2c-1/new_device
     [[ -e /dev/rtc0 ]] && return 0
     echo 0x68 >/sys/class/i2c-dev/i2c-1/device/delete_device
 
     # check for DS1307
     modprobe i2c:ds1307
+    echo ds1307 0x68 >/sys/class/i2c-adapter/i2c-1/new_device
     [[ -e /dev/rtc0 ]] && return 0
     echo 0x68 >/sys/class/i2c-dev/i2c-1/device/delete_device
   fi


### PR DESCRIPTION
DS3231/DS1307 was not available after boot.

`hwclock: can't open '/dev/misc/rtc': No such file or directory`
