### PR TITLE
Security Key can only be set with a working BidCos-RF interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The RaspberryMatic project is a collaborate effort to provide a lightweight, [Li
 * No HomeMatic-IP support with HM-MOD-RPI-PCB on ASUS Tinkerboard (work in progress)
 * No Bluetooth and onboard-WiFi support for ASUS Tinkerboard (work in progress)
 * A used [HM-Sys-sRP-Pl](https://www.elv.de/controller.aspx?cid=683&detail=10&detail2=731493) repeater cannot be reconfigured
+* A Security Key can only be configured if you have a working BidCos-RF interface(HM-MOD-RPI-PCB or LAN Gateway)
 
 ## :computer: Requirements
 <img src="https://files.elv.com/bilder/artikel/Produkte/14/1421/142141/Internet/gross/142141_F02_PlHomeMatic.jpg" alt="RaspberryPi equipped with HM-MOD-RPI-PCB" width=300 align=right>


### PR DESCRIPTION
Expanded the Limitations Section