### PR TITLE
Feature - WebUI DutyCycle

### DIFF
--- a/buildroot-external/patches/occu/0033-WebUI-DutyCycle.patch
+++ b/buildroot-external/patches/occu/0033-WebUI-DutyCycle.patch
@@ -1,0 +1,22 @@
+--- occu/etc/config_templates/crontab.root.orig
++++ occu/etc/config_templates/crontab.root
+@@ -1,3 +1,4 @@
+ 12 4 * * * /bin/setHWClock.sh
+ 14 4 * * * /bin/SetInterfaceClock 127.0.0.1:2001
+ 0 4 * * * /usr/sbin/logrotate -f /etc/logrotate.conf || logger -p error -t "logrotate" "logrotate aborted with error $?"
++*/3 * * * * /bin/dutyccu
+--- occu/etc/init.d/S00eQ3SystemStart.orig
++++ occu/etc/init.d/S00eQ3SystemStart
+@@ -68,7 +68,11 @@
+                 sed 's/setInterfaceClock/SetInterfaceClock/g' /usr/local/crontabs/root > /usr/local/crontabs/root.tmp
+                 mv /usr/local/crontabs/root.tmp /usr/local/crontabs/root
+         fi
+-
++        grep "dutyccu" /usr/local/crontabs/root
++        if [ $? == 1 ] ; then
++                echo "added dutyccu"
++                echo '*/3 * * * * /bin/dutyccu' >> /usr/local/crontabs/root
++        fi
+         
+ 	if [ ! -e /usr/local/etc/config/shadow ] ; then
+ 		cp $CFG_TEMPLATE_DIR/shadow /usr/local/etc/config/shadow

--- a/buildroot-external/patches/occu/0033-WebUI-DutyCycle/occu/bin/dutyccu
+++ b/buildroot-external/patches/occu/0033-WebUI-DutyCycle/occu/bin/dutyccu
@@ -1,0 +1,149 @@
+#!/bin/tclsh
+
+# DutyCycle Script v.2.2 developed by Andreas Bünting (HMside)
+# Dieses Script liest den DutyCycle Status der HomeMatic CCU und Gateways aus
+# und erstellt automatisch eine Systemvariable vom Typ Zahl mit dem Gateway Namen bzw. alternativ mit der Geräte-Seriennummer.
+# Wird der Gateway Name nachträglich gesetzt, wird die zuvor erstellte Systemvariable automatisch umbenannt.
+# Zudem wird eine DutyCycle System-Log Meldung erzeugt und für den Support eine Datei mit dem DC-Status im User-Verzeichnis angelegt.
+# Für den HM-CFG-LAN wird der DutyCycle Status bei einer Verbindungsunterbrechung auf -1 gesetzt.
+
+load tclrpc.so
+load tclrega.so
+
+set CONFIG_FILE {/usr/local/etc/config/rfd.conf}
+set gateways [xmlrpc http://127.0.0.1:2001/ listBidcosInterfaces]
+#puts $gateways
+
+# DC-File anlegen um den DutyCycle Status für den Support anhand eines Backups sichtbar zu machen
+close [open /usr/local/etc/config/dc "w"]
+set date [clock seconds]
+set date [clock format $date -format {%d.%m.%Y %T}]
+
+# Gateway Konfiguration aus rfd.conf einlesen
+array set config {}
+array set section {}
+set sectionName {}
+
+catch {
+  set fd [open $CONFIG_FILE r]
+  catch {
+    while { ![eof $fd] } {
+      set line [string trimleft [gets $fd]]
+      if { "\#" != [string index $line 0] } then {
+        if { [regexp {\[([^\]]+)\]} $line dummy newSectionName] } then {
+          set config($sectionName) [array get section]
+          set sectionName $newSectionName
+        }
+        if { [regexp {([^=]+)=(.+)} $line dummy name value] } then {
+          set section([string trim $name]) [string trim $value]
+        }
+      }
+    }
+    set config($sectionName) [array get section]
+  }
+  close $fd
+}
+
+# Zentralen und Gateway DutyCycle sowie weitere Infos abfragen
+set lines [split [string map [list "{AD" "\x00"] $gateways] "\x00"]
+
+regsub -all "]" $lines "" lines
+regsub -all "{" $lines "" lines
+regsub -all "}" $lines "" lines
+
+set ccuoben ""
+set gwoben ""
+set interfaces {}
+set gwname {}
+
+foreach line $lines {
+  set snoben ""
+  set dutycycle ""
+  set type ""
+  set type1 ""
+
+  regexp "DRESS (.*?) " $line dummy snoben
+  regexp "CONNECTED (.*?) " $line dummy connection
+  regexp "DUTY_CYCLE (.*?) " $line dummy dutycycle
+  regexp "FIRMWARE_VERSION (.*?) " $line dummy fw
+  regexp "TYPE (.+)" $line dummy type
+  regsub -all {\\} $type "" type1
+  regsub -all " " $type1 "" type2
+
+  if {$type2 == "CCU2"} {
+    set ccuoben $snoben
+    set ccutype "DutyCycle"
+    puts "--------------------"
+    puts $ccuoben
+    puts "$connection / $dutycycle"
+    puts "$ccutype / $fw"
+    # Prüfen ob DC Systemvariable für CCU2 existiert und ggf. anlegen
+    append rega_cmd_create_sv "string svName ='$ccutype';object svObj = dom.GetObject(svName);if (!svObj){object svObjects = dom.GetObject(ID_SYSTEM_VARIABLES);svObj = dom.CreateObject(OT_VARDP);svObjects.Add(svObj.ID());svObj.Name(svName);svObj.ValueType(ivtFloat);svObj.ValueSubType(istGeneric);svObj.DPInfo('nicht löschen');svObj.ValueUnit('%');svObj.ValueMin(-100);svObj.ValueMax(100);svObj.State(0);svObj.Internal(false);svObj.Visible(true);dom.RTUpdate(true);}"
+    rega_script $rega_cmd_create_sv
+    # CCU DutyCycle Variable aktualisieren
+    append rega_cmd "dom.GetObject(ID_SYSTEM_VARIABLES).Get('$ccutype').State('$dutycycle');"
+    rega_script $rega_cmd
+    # CCU DutyCycle System-Log Meldung erzeugen
+    exec logger -t dutycycle -p info "$ccutype-CCU / FW: $fw / DC: $dutycycle %"
+    # Datum/Uhrzeit und CCU DutyCycle in DC-File schreiben
+    exec echo "$date" >> /usr/local/etc/config/dc
+    exec echo "$ccuoben=$dutycycle\nCONNECTED=$connection\nFIRMWARE=$fw" >> /usr/local/etc/config/dc
+    } else {
+      # Sektion für Gateways
+      set gwoben $snoben
+      puts "--------------------"
+      puts "$connection / $dutycycle"
+      puts "$gwoben / $fw"
+
+      foreach sectionName [array names config] {
+        array set section $config($sectionName)
+        set sn [array get section {Serial Number}]
+        set sn1 $section(Serial Number)
+        if { $sn1 == $gwoben } then {
+          array set interface {}
+          set interface(userName)      [array get section {Name}]
+          lappend interfaces [array get interface]
+          set gwname $section(Name)
+          set gwname1 "DutyCycle-$gwname"
+          set gwnoname "DutyCycle-$sn1"
+          # Wenn kein Gateway Name eingetragen wurde, wird als Variablenname "DutyCycle-Seriennummer" gesetzt
+          if { $gwname == "" } then {
+            puts $gwnoname
+            # Wenn HM-CFG-LAN disconnected dann DC -1 setzen
+            if {($type2 == "LanInterface") && ($connection == "0" )} then {
+              set dutycycle -1
+            }
+            # Prüfen ob DC Systemvariable für Gateways existieren und ggf. anlegen
+            append rega_cmd_create_sv "string svName = '$gwnoname';object svObj = dom.GetObject(svName);if (!svObj){object svObjects = dom.GetObject(ID_SYSTEM_VARIABLES);svObj = dom.CreateObject(OT_VARDP);svObjects.Add(svObj.ID());svObj.Name(svName);svObj.ValueType(ivtFloat);svObj.ValueSubType(istGeneric);svObj.DPInfo('nicht löschen');svObj.ValueUnit('%');svObj.ValueMin(-100);svObj.ValueMax(100);svObj.State(0);svObj.Internal(false);svObj.Visible(true);dom.RTUpdate(true);}"
+            rega_script $rega_cmd_create_sv
+            # DutyCycle Variable aktualisieren
+            append rega_cmd "dom.GetObject(ID_SYSTEM_VARIABLES).Get('$gwnoname').State('$dutycycle');"
+            rega_script $rega_cmd
+            # DutyCycle System-Log Meldung erzeugen
+            exec logger -t dutycycle -p info "$gwnoname / FW: $fw / DC: $dutycycle %"
+            # DutyCycle in DC-File schreiben
+            exec echo "$sn1=$dutycycle$\nCONNECTED=$connection\nFIRMWARE=$fw" >> /usr/local/etc/config/dc
+            } else {
+              puts $gwname1
+              if {($type2 == "LanInterface") && ($connection == "0" )} then {
+                set dutycycle -1
+                #puts "$type2 nicht verbunden DC=$dutycycle"
+              }
+              # Wird der Gateway Name nachträglich gesetzt, Systemvariable mit Seriennummer umbenennen
+              append rega_cmd_rename_sv "string svName = '$gwnoname';string svNewName = '$gwname1';object svObj = dom.GetObject(svName);if (svObj){dom.GetObject(svName).Name(svNewName);dom.RTUpdate(true)};"
+              rega_script $rega_cmd_rename_sv
+              # Wenn ein Gateway Name eingetragen wurde, wird dieser angehangen z.B. "DutyCycle-OG1"
+              append rega_cmd_create_sv "string svName = '$gwname1';object svObj  = dom.GetObject(svName);if (!svObj){object svObjects = dom.GetObject(ID_SYSTEM_VARIABLES);svObj = dom.CreateObject(OT_VARDP);svObjects.Add(svObj.ID());svObj.Name(svName);svObj.ValueType(ivtFloat);svObj.ValueSubType(istGeneric);svObj.DPInfo('nicht löschen');svObj.ValueUnit('%');svObj.ValueMin(-100);svObj.ValueMax(100);svObj.State(0);svObj.Internal(false);svObj.Visible(true);dom.RTUpdate(true);}"
+              rega_script $rega_cmd_create_sv
+              # DutyCycle Variable aktualisieren
+              append rega_cmd "dom.GetObject(ID_SYSTEM_VARIABLES).Get('$gwname1').State('$dutycycle');"
+              rega_script $rega_cmd
+              # DutyCycle System-Log Meldung erzeugen
+              exec logger -t dutycycle -p info "$gwname1 / FW: $fw / DC: $dutycycle %"
+              # DutyCycle in DC-File schreiben
+              exec echo "$sn1=$dutycycle\nCONNECTED=$connection\nFIRMWARE=$fw" >> /usr/local/etc/config/dc
+            }
+        }
+      }
+    }
+  }

--- a/buildroot-external/patches/occu/0033-WebUI-DutyCycle/occu/etc/config_templates/crontab.root
+++ b/buildroot-external/patches/occu/0033-WebUI-DutyCycle/occu/etc/config_templates/crontab.root
@@ -1,0 +1,4 @@
+12 4 * * * /bin/setHWClock.sh
+14 4 * * * /bin/SetInterfaceClock 127.0.0.1:2001
+0 4 * * * /usr/sbin/logrotate -f /etc/logrotate.conf || logger -p error -t "logrotate" "logrotate aborted with error $?"
+*/3 * * * * /bin/dutyccu

--- a/buildroot-external/patches/occu/0033-WebUI-DutyCycle/occu/etc/config_templates/crontab.root.orig
+++ b/buildroot-external/patches/occu/0033-WebUI-DutyCycle/occu/etc/config_templates/crontab.root.orig
@@ -1,0 +1,3 @@
+12 4 * * * /bin/setHWClock.sh
+14 4 * * * /bin/SetInterfaceClock 127.0.0.1:2001
+0 4 * * * /usr/sbin/logrotate -f /etc/logrotate.conf || logger -p error -t "logrotate" "logrotate aborted with error $?"

--- a/buildroot-external/patches/occu/0033-WebUI-DutyCycle/occu/etc/init.d/S00eQ3SystemStart
+++ b/buildroot-external/patches/occu/0033-WebUI-DutyCycle/occu/etc/init.d/S00eQ3SystemStart
@@ -1,0 +1,159 @@
+#!/bin/sh
+#
+# set System Start Led Signal
+#
+
+CFG_TEMPLATE_DIR=/etc/config_templates
+SERIAL=$(cat /sys/module/plat_eq3ccu2/parameters/board_serial)
+
+init() {
+	# power led on
+	echo 255 > /sys/class/leds/power/brightness
+	echo default-on > /sys/class/leds/power/trigger
+	# internet led off
+	echo none > /sys/class/leds/internet/trigger
+	# info led fast
+	echo timer > /sys/class/leds/info/trigger
+	echo 255 > /sys/class/leds/info/brightness
+	echo 100 > /sys/class/leds/info/delay_off
+	echo 100 > /sys/class/leds/info/delay_on
+
+        chmod 775 /var
+        mkdir /var/log
+        chmod 775 /var/log
+        mkdir /var/tmp
+        chmod 775 /var/tmp
+        mkdir /var/rega
+        chmod 775 /var/rega
+        mkdir /var/run
+        chmod 775 /var/run
+        mkdir /var/spool
+        chmod 775 /var/spool
+        mkdir /var/lock
+        chmod 775 /var/lock
+        mkdir /var/cache
+        chmod 775 /var/cache
+        mkdir /var/lib
+        chmod 775 /var/lib
+        mkdir /var/lib/misc
+        chmod 775 /var/lib/misc
+        mkdir /var/empty
+        chmod 600 /var/empty
+        mkdir /var/etc
+        chmod 775 /var/etc
+	#
+	# crontab dirs
+        mkdir -p /var/spool/cron
+        chmod 775 /var/spool
+        chmod 775 /var/spool/cron
+        if [ ! -d /usr/local/crontabs ] ; then
+        	mkdir -p /usr/local/crontabs
+        	chmod 775 /usr/local/crontabs
+        fi
+	ln -s /usr/local/crontabs /var/spool/cron/crontabs 
+        if [ ! -e /usr/local/crontabs/root ] ; then
+                cp $CFG_TEMPLATE_DIR/crontab.root /usr/local/crontabs/root
+		else
+				#if /usr/local/contabs/root exists, ensure that logrotate entry exists
+				cat /usr/local/crontabs/root | grep -q logrotate
+				if [ $? -ne 0 ]
+				then
+					echo '0 4 * * * /usr/sbin/logrotate -f /etc/logrotate.conf || logger -p error -t "logrotate" "logrotate aborted with error $?"' >> /usr/local/crontabs/root
+				fi
+        fi
+        # Bug fix
+        grep "setInterfaceClock" /usr/local/crontabs/root
+        if [ $? == 0 ] ; then
+                echo "update crontab file"
+                sed 's/setInterfaceClock/SetInterfaceClock/g' /usr/local/crontabs/root > /usr/local/crontabs/root.tmp
+                mv /usr/local/crontabs/root.tmp /usr/local/crontabs/root
+        fi
+        grep "dutyccu" /usr/local/crontabs/root
+        if [ $? == 1 ] ; then
+                echo "added dutyccu"
+                echo '*/3 * * * * /bin/dutyccu' >> /usr/local/crontabs/root
+        fi
+        
+	if [ ! -e /usr/local/etc/config/shadow ] ; then
+		cp $CFG_TEMPLATE_DIR/shadow /usr/local/etc/config/shadow
+	fi
+
+	modprobe spidev
+        modprobe ic200_spi
+        modprobe spi_eq3_gpio
+        modprobe spi_bitbang
+        mknod spidev0.0 c 153 0
+        modprobe gpio-keys
+        modprobe fsl_usb2_udc.ko
+	if grep -q "eQ3Mode=production" /proc/cmdline ; then
+          modprobe g_multi luns=1 cdrom=1 ro=1 removable=0,0 file=/usr/share/eq3/install.iso host_addr=00:1a:22:00:05:86 dev_addr=00:1a:22:00:05:87 iManufacturer="eQ-3" iProduct="CCU2" idVendor="0x1b1f" idProduct="0xc016" iSerialNumber="$SERIAL"
+	fi
+	
+	# Tunneling
+        modprobe tun
+       
+	# USB
+        modprobe ehci-hcd
+
+	# HM/HmIP Dual Protocol
+	modprobe mxs_raw_auart
+	modprobe eq3_char_loop
+	 
+	if [ ! -d /usr/local/etc/config ] ; then
+                mkdir -p /usr/local/etc/config
+        	chmod 775 /usr/local/etc/config
+        fi
+
+
+        if [ ! -e /etc/config/TZ ] ; then
+                cp $CFG_TEMPLATE_DIR/TZ /etc/config
+        fi
+        if [ ! -e /etc/config/netconfig ] ; then
+                cp $CFG_TEMPLATE_DIR/netconfig /etc/config
+        fi
+        if [ ! -e /etc/config/shadow ] ; then
+                cp $CFG_TEMPLATE_DIR/shadow /etc/config
+        fi
+
+	export TZ=`cat /etc/config/TZ`
+ 
+}
+
+start() {
+	echo -n "LED Code: System start: "
+	init
+	echo "OK"
+    # Firewall konfigurieren
+    echo -n "Init Firewall: "
+    setfirewall.tcl
+	echo -n "Starting crond: "
+	start-stop-daemon -S -q -p /var/run/crond.pid --exec /usr/sbin/crond	
+	echo "OK"
+}
+
+stop () {
+	start-stop-daemon -K -q -p /var/run/crond.pid
+	/bin/update_firmware_pre
+}
+
+restart() {
+	start
+}
+
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  restart|reload)
+	restart
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart}"
+	exit 1
+esac
+
+exit $?
+

--- a/buildroot-external/patches/occu/0033-WebUI-DutyCycle/occu/etc/init.d/S00eQ3SystemStart.orig
+++ b/buildroot-external/patches/occu/0033-WebUI-DutyCycle/occu/etc/init.d/S00eQ3SystemStart.orig
@@ -1,0 +1,155 @@
+#!/bin/sh
+#
+# set System Start Led Signal
+#
+
+CFG_TEMPLATE_DIR=/etc/config_templates
+SERIAL=$(cat /sys/module/plat_eq3ccu2/parameters/board_serial)
+
+init() {
+	# power led on
+	echo 255 > /sys/class/leds/power/brightness
+	echo default-on > /sys/class/leds/power/trigger
+	# internet led off
+	echo none > /sys/class/leds/internet/trigger
+	# info led fast
+	echo timer > /sys/class/leds/info/trigger
+	echo 255 > /sys/class/leds/info/brightness
+	echo 100 > /sys/class/leds/info/delay_off
+	echo 100 > /sys/class/leds/info/delay_on
+
+        chmod 775 /var
+        mkdir /var/log
+        chmod 775 /var/log
+        mkdir /var/tmp
+        chmod 775 /var/tmp
+        mkdir /var/rega
+        chmod 775 /var/rega
+        mkdir /var/run
+        chmod 775 /var/run
+        mkdir /var/spool
+        chmod 775 /var/spool
+        mkdir /var/lock
+        chmod 775 /var/lock
+        mkdir /var/cache
+        chmod 775 /var/cache
+        mkdir /var/lib
+        chmod 775 /var/lib
+        mkdir /var/lib/misc
+        chmod 775 /var/lib/misc
+        mkdir /var/empty
+        chmod 600 /var/empty
+        mkdir /var/etc
+        chmod 775 /var/etc
+	#
+	# crontab dirs
+        mkdir -p /var/spool/cron
+        chmod 775 /var/spool
+        chmod 775 /var/spool/cron
+        if [ ! -d /usr/local/crontabs ] ; then
+        	mkdir -p /usr/local/crontabs
+        	chmod 775 /usr/local/crontabs
+        fi
+	ln -s /usr/local/crontabs /var/spool/cron/crontabs 
+        if [ ! -e /usr/local/crontabs/root ] ; then
+                cp $CFG_TEMPLATE_DIR/crontab.root /usr/local/crontabs/root
+		else
+				#if /usr/local/contabs/root exists, ensure that logrotate entry exists
+				cat /usr/local/crontabs/root | grep -q logrotate
+				if [ $? -ne 0 ]
+				then
+					echo '0 4 * * * /usr/sbin/logrotate -f /etc/logrotate.conf || logger -p error -t "logrotate" "logrotate aborted with error $?"' >> /usr/local/crontabs/root
+				fi
+        fi
+        # Bug fix
+        grep "setInterfaceClock" /usr/local/crontabs/root
+        if [ $? == 0 ] ; then
+                echo "update crontab file"
+                sed 's/setInterfaceClock/SetInterfaceClock/g' /usr/local/crontabs/root > /usr/local/crontabs/root.tmp
+                mv /usr/local/crontabs/root.tmp /usr/local/crontabs/root
+        fi
+
+        
+	if [ ! -e /usr/local/etc/config/shadow ] ; then
+		cp $CFG_TEMPLATE_DIR/shadow /usr/local/etc/config/shadow
+	fi
+
+	modprobe spidev
+        modprobe ic200_spi
+        modprobe spi_eq3_gpio
+        modprobe spi_bitbang
+        mknod spidev0.0 c 153 0
+        modprobe gpio-keys
+        modprobe fsl_usb2_udc.ko
+	if grep -q "eQ3Mode=production" /proc/cmdline ; then
+          modprobe g_multi luns=1 cdrom=1 ro=1 removable=0,0 file=/usr/share/eq3/install.iso host_addr=00:1a:22:00:05:86 dev_addr=00:1a:22:00:05:87 iManufacturer="eQ-3" iProduct="CCU2" idVendor="0x1b1f" idProduct="0xc016" iSerialNumber="$SERIAL"
+	fi
+	
+	# Tunneling
+        modprobe tun
+       
+	# USB
+        modprobe ehci-hcd
+
+	# HM/HmIP Dual Protocol
+	modprobe mxs_raw_auart
+	modprobe eq3_char_loop
+	 
+	if [ ! -d /usr/local/etc/config ] ; then
+                mkdir -p /usr/local/etc/config
+        	chmod 775 /usr/local/etc/config
+        fi
+
+
+        if [ ! -e /etc/config/TZ ] ; then
+                cp $CFG_TEMPLATE_DIR/TZ /etc/config
+        fi
+        if [ ! -e /etc/config/netconfig ] ; then
+                cp $CFG_TEMPLATE_DIR/netconfig /etc/config
+        fi
+        if [ ! -e /etc/config/shadow ] ; then
+                cp $CFG_TEMPLATE_DIR/shadow /etc/config
+        fi
+
+	export TZ=`cat /etc/config/TZ`
+ 
+}
+
+start() {
+	echo -n "LED Code: System start: "
+	init
+	echo "OK"
+    # Firewall konfigurieren
+    echo -n "Init Firewall: "
+    setfirewall.tcl
+	echo -n "Starting crond: "
+	start-stop-daemon -S -q -p /var/run/crond.pid --exec /usr/sbin/crond	
+	echo "OK"
+}
+
+stop () {
+	start-stop-daemon -K -q -p /var/run/crond.pid
+	/bin/update_firmware_pre
+}
+
+restart() {
+	start
+}
+
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  restart|reload)
+	restart
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart}"
+	exit 1
+esac
+
+exit $?
+


### PR DESCRIPTION
Zweiter Teil der DuytCycle Anzeige:
 
Das verwendete Tcl Skript liest den DutyCycle Status der Zentrale und der eingebundenen Gateways aus und erstellt jeweils automatisch eine Systemvariable vom Typ Zahl mit dem Gateway Namen bzw. alternativ der Geräte-Seriennummer. Wird der Gateway Name vom User nachträglich gesetzt, wird die zuvor erstellte Systemvariable automatisch umbenannt. Zudem wird eine DutyCycle System-Log Meldung erzeugt und für den Support eine Datei mit dem DutyCycle Status im User-Verzeichnis angelegt. Für den HM-CFG-LAN wird der DutyCycle Status bei einer Netzwerk Verbindungsunterbrechung auf -1 gesetzt, so kann wie auch beim HM-LGW-O-TW-W-EU über ein Zentralenprogramm auf eine Verbindungsunterbrechung reagiert werden.

Hinweis: Die Systemvariablen erscheinen ca. 3 Minuten nach dem Zentralen Start!

Mit diesem Patch und #301 sollte dann #219 geschlossen werden können.

Status und Bedienung > Systemvariablen
![dc](https://user-images.githubusercontent.com/13312068/38455764-167d1c2c-3a7d-11e8-9aab-1420e142580a.png)

Anzeige auf der Startseite (Variablen müssen über die Benutzerverwaltung hinzugefügt werden)
![dc1](https://user-images.githubusercontent.com/13312068/38455831-c876ed5e-3a7d-11e8-862f-92cf8ff870a0.png)
