### PR TITLE
Update: updateDCVars.tcl

### DIFF
--- a/buildroot-external/overlay/base-raspmatic/bin/updateDCVars.tcl
+++ b/buildroot-external/overlay/base-raspmatic/bin/updateDCVars.tcl
@@ -1,23 +1,18 @@
 #!/bin/tclsh
 
-# DutyCycle Script v.2.2 developed by Andreas B¸nting (HMside)
+# DutyCycle Script v.2.4 developed by Andreas B√ºnting
 # Dieses Script liest den DutyCycle Status der HomeMatic CCU und Gateways aus
-# und erstellt automatisch eine Systemvariable vom Typ Zahl mit dem Gateway Namen bzw. alternativ mit der Ger‰te-Seriennummer.
-# Wird der Gateway Name nachtr‰glich gesetzt, wird die zuvor erstellte Systemvariable automatisch umbenannt.
-# Zudem wird eine DutyCycle System-Log Meldung erzeugt und f¸r den Support eine Datei mit dem DC-Status im User-Verzeichnis angelegt.
-# F¸r den HM-CFG-LAN wird der DutyCycle Status bei einer Verbindungsunterbrechung auf -1 gesetzt.
+# und erstellt automatisch eine Systemvariable vom Typ Zahl mit dem Gateway Namen bzw. alternativ mit der Ger√§te-Seriennummer.
+# Wird der Gateway Name nachtr√§glich gesetzt, wird die zuvor erstellte Systemvariable automatisch umbenannt.
+# Zudem wird eine DutyCycle System-Log Meldung erzeugt, sofern der DutyCycle √ºber 80% steigt.
+# F√ºr den HM-CFG-LAN wird der DutyCycle Status bei einer Verbindungsunterbrechung auf -1 gesetzt.
+# Sofern Wired-Gateway eingebunden, wird eine Systemvariabel mit dem Namen "Wired-Status" und den Zust√§nden "online/offline" angelegt
 
 load tclrpc.so
 load tclrega.so
 
 set CONFIG_FILE {/usr/local/etc/config/rfd.conf}
 set gateways [xmlrpc http://127.0.0.1:2001/ listBidcosInterfaces]
-#puts $gateways
-
-# DC-File anlegen um den DutyCycle Status f¸r den Support anhand eines Backups sichtbar zu machen
-#close [open /usr/local/etc/config/dc "w"]
-#set date [clock seconds]
-#set date [clock format $date -format {%d.%m.%Y %T}]
 
 # Gateway Konfiguration aus rfd.conf einlesen
 array set config {}
@@ -44,7 +39,7 @@ catch {
   close $fd
 }
 
-# Zentralen und Gateway DutyCycle sowie weitere Infos abfragen
+# Zentralen und Gateway DutyCycle und weitere Infos abfragen
 set lines [split [string map [list "{AD" "\x00"] $gateways] "\x00"]
 
 regsub -all "]" $lines "" lines
@@ -57,93 +52,148 @@ set interfaces {}
 set gwname {}
 
 foreach line $lines {
+
   set snoben ""
   set dutycycle ""
   set type ""
-  set type1 ""
 
-  regexp "DRESS (.*?) " $line dummy snoben
-  regexp "CONNECTED (.*?) " $line dummy connection
-  regexp "DUTY_CYCLE (.*?) " $line dummy dutycycle
-  regexp "FIRMWARE_VERSION (.*?) " $line dummy fw
+  regexp "DRESS (.+?) " $line dummy snoben
+  regexp "CONNECTED (.+?) " $line dummy connection
+  regexp "DUTY_CYCLE (.+?) " $line dummy dutycycle
+  regexp "FIRMWARE_VERSION (.+?) " $line dummy fw
   regexp "TYPE (.+)" $line dummy type
-  regsub -all {\\} $type "" type1
-  regsub -all " " $type1 "" type2
+  regsub -all {\\} $type "" type
+  regsub -all " " $type "" type
 
-  if {$type2 == "CCU2"} {
+  if {$type == "CCU2"} {
     set ccuoben $snoben
     set ccutype "DutyCycle"
     puts "--------------------"
-    puts $ccuoben
-    puts "$connection / $dutycycle"
-    puts "$ccutype / $fw"
-    # Pr¸fen ob DC Systemvariable f¸r CCU2 existiert und ggf. anlegen
-    append rega_cmd_create_sv "string svName ='$ccutype';object svObj = dom.GetObject(svName);if (!svObj){object svObjects = dom.GetObject(ID_SYSTEM_VARIABLES);svObj = dom.CreateObject(OT_VARDP);svObjects.Add(svObj.ID());svObj.Name(svName);svObj.ValueType(ivtFloat);svObj.ValueSubType(istGeneric);svObj.DPInfo('DutyCycle CCU');svObj.ValueUnit('%');svObj.ValueMin(-100);svObj.ValueMax(100);svObj.State(0);svObj.Internal(false);svObj.Visible(true);dom.RTUpdate(true);}"
+    puts "$dutycycle %"
+    puts "$ccuoben / $fw"
+    puts "$ccutype-CCU"
+    # Pr√ºfen ob DC Systemvariable f√ºr CCU2 existiert und ggf. anlegen
+    append rega_cmd_create_sv "string svName ='$ccutype';object svObj = dom.GetObject(ID_SYSTEM_VARIABLES).Get(svName);if (!svObj){object svObjects = dom.GetObject(ID_SYSTEM_VARIABLES);svObj = dom.CreateObject(OT_VARDP);svObjects.Add(svObj.ID());svObj.Name(svName);svObj.ValueType(ivtFloat);svObj.ValueSubType(istGeneric);svObj.DPInfo('DutyCycle CCU');svObj.ValueUnit('%');svObj.ValueMin(-100);svObj.ValueMax(100);svObj.State(0);svObj.Internal(false);svObj.Visible(true);dom.RTUpdate(true);}"
     rega_script $rega_cmd_create_sv
     # CCU DutyCycle Variable aktualisieren
     append rega_cmd "dom.GetObject(ID_SYSTEM_VARIABLES).Get('$ccutype').State('$dutycycle');"
     rega_script $rega_cmd
-    # CCU DutyCycle System-Log Meldung erzeugen
-    exec logger -t dutycycle -p info "$ccutype-CCU / FW: $fw / DC: $dutycycle %"
-    # Datum/Uhrzeit und CCU DutyCycle in DC-File schreiben
-    #exec echo "$date" >> /usr/local/etc/config/dc
-    #exec echo "$ccuoben=$dutycycle\nCONNECTED=$connection\nFIRMWARE=$fw" >> /usr/local/etc/config/dc
-    } else {
-      # Sektion f¸r Gateways
-      set gwoben $snoben
-      puts "--------------------"
-      puts "$connection / $dutycycle"
-      puts "$gwoben / $fw"
+    # CCU DutyCycle System-Log Meldung erzeugen sofern DC gr√∂√üer 80%
+    if {$dutycycle >= "80"} {
+      exec logger -t dutycycle -p info "$ccutype-CCU / FW: $fw / DC: $dutycycle %"
+    }
+  }
 
-      foreach sectionName [array names config] {
-        array set section $config($sectionName)
-        set sn [array get section {Serial Number}]
-        set sn1 $section(Serial Number)
-        if { $sn1 == $gwoben } then {
-          array set interface {}
-          set interface(userName)      [array get section {Name}]
-          lappend interfaces [array get interface]
-          set gwname $section(Name)
-          set gwname1 "DutyCycle-$gwname"
-          set gwnoname "DutyCycle-$sn1"
-          # Wenn kein Gateway Name eingetragen wurde, wird als Variablenname "DutyCycle-Seriennummer" gesetzt
-          if { $gwname == "" } then {
-            puts $gwnoname
-            # Wenn HM-CFG-LAN disconnected dann DC -1 setzen
-            if {($type2 == "LanInterface") && ($connection == "0" )} then {
-              set dutycycle -1
-            }
-            # Pr¸fen ob DC Systemvariable f¸r Gateways existieren und ggf. anlegen
-            append rega_cmd_create_sv "string svName = '$gwnoname';object svObj = dom.GetObject(svName);if (!svObj){object svObjects = dom.GetObject(ID_SYSTEM_VARIABLES);svObj = dom.CreateObject(OT_VARDP);svObjects.Add(svObj.ID());svObj.Name(svName);svObj.ValueType(ivtFloat);svObj.ValueSubType(istGeneric);svObj.DPInfo('DutyCycle Gateway');svObj.ValueUnit('%');svObj.ValueMin(-100);svObj.ValueMax(100);svObj.State(0);svObj.Internal(false);svObj.Visible(true);dom.RTUpdate(true);}"
-            rega_script $rega_cmd_create_sv
-            # DutyCycle Variable aktualisieren
-            append rega_cmd "dom.GetObject(ID_SYSTEM_VARIABLES).Get('$gwnoname').State('$dutycycle');"
-            rega_script $rega_cmd
-            # DutyCycle System-Log Meldung erzeugen
-            exec logger -t dutycycle -p info "$gwnoname / FW: $fw / DC: $dutycycle %"
-            # DutyCycle in DC-File schreiben
-            #exec echo "$sn1=$dutycycle$\nCONNECTED=$connection\nFIRMWARE=$fw" >> /usr/local/etc/config/dc
+  # Sektion f√ºr Gateways
+  set gwoben $snoben
+  foreach sectionName [array names config] {
+    if { {} != $sectionName } then {
+      array set section $config($sectionName)
+      set type2 [array get section {Type}]
+        if { ($type2 != "Type CCU2") } then {
+          set sn1 $section(Serial Number)
+          if { $sn1 == $gwoben } then {
+            if { $connection == 1 } then {
+              set con "Online"
             } else {
-              puts $gwname1
-              if {($type2 == "LanInterface") && ($connection == "0" )} then {
+              set con "Offline"
+            }
+            puts "--------------------"
+            puts "$con / $dutycycle %"
+            puts "$gwoben / $fw"
+
+            set gwname $section(Name)
+            set gwname1 "DutyCycle-$gwname"
+            set gwnoname "DutyCycle-$sn1"
+            # Wenn kein Gateway Name eingetragen wurde, wird als Variablenname "DutyCycle-Seriennummer" gesetzt
+            if { $gwname == "" } then {
+              puts $gwnoname
+              # Wenn HM-CFG-LAN disconnected dann DC -1 setzen
+              if {($type == "LanInterface") && ($connection == "0" )} then {
                 set dutycycle -1
-                #puts "$type2 nicht verbunden DC=$dutycycle"
+                puts "Set DC to $dutycycle"
               }
-              # Wird der Gateway Name nachtr‰glich gesetzt, Systemvariable mit Seriennummer umbenennen
-              append rega_cmd_rename_sv "string svName = '$gwnoname';string svNewName = '$gwname1';object svObj = dom.GetObject(svName);if (svObj){dom.GetObject(svName).Name(svNewName);dom.RTUpdate(true)};"
-              rega_script $rega_cmd_rename_sv
-              # Wenn ein Gateway Name eingetragen wurde, wird dieser angehangen z.B. "DutyCycle-OG1"
-              append rega_cmd_create_sv "string svName = '$gwname1';object svObj  = dom.GetObject(svName);if (!svObj){object svObjects = dom.GetObject(ID_SYSTEM_VARIABLES);svObj = dom.CreateObject(OT_VARDP);svObjects.Add(svObj.ID());svObj.Name(svName);svObj.ValueType(ivtFloat);svObj.ValueSubType(istGeneric);svObj.DPInfo('DutyCycle Gateway');svObj.ValueUnit('%');svObj.ValueMin(-100);svObj.ValueMax(100);svObj.State(0);svObj.Internal(false);svObj.Visible(true);dom.RTUpdate(true);}"
+              # Pr√ºfen ob DC Systemvariable f√ºr Gateways existieren und ggf. anlegen
+              append rega_cmd_create_sv "string svName = '$gwnoname';object svObj = dom.GetObject(ID_SYSTEM_VARIABLES).Get(svName);if (!svObj){object svObjects = dom.GetObject(ID_SYSTEM_VARIABLES);svObj = dom.CreateObject(OT_VARDP);svObjects.Add(svObj.ID());svObj.Name(svName);svObj.ValueType(ivtFloat);svObj.ValueSubType(istGeneric);svObj.DPInfo('DutyCycle Gateway');svObj.ValueUnit('%');svObj.ValueMin(-100);svObj.ValueMax(100);svObj.State(0);svObj.Internal(false);svObj.Visible(true);dom.RTUpdate(true);}"
               rega_script $rega_cmd_create_sv
               # DutyCycle Variable aktualisieren
-              append rega_cmd "dom.GetObject(ID_SYSTEM_VARIABLES).Get('$gwname1').State('$dutycycle');"
+              append rega_cmd "dom.GetObject(ID_SYSTEM_VARIABLES).Get('$gwnoname').State('$dutycycle');"
               rega_script $rega_cmd
-              # DutyCycle System-Log Meldung erzeugen
-              exec logger -t dutycycle -p info "$gwname1 / FW: $fw / DC: $dutycycle %"
-              # DutyCycle in DC-File schreiben
-              #exec echo "$sn1=$dutycycle\nCONNECTED=$connection\nFIRMWARE=$fw" >> /usr/local/etc/config/dc
+              # DutyCycle System-Log Meldung erzeugen sofern DC gr√∂√üer 80%
+              if {$dutycycle >= "80"} {
+                exec logger -t dutycycle -p info "$gwnoname / FW: $fw / DC: $dutycycle %"
+              }
+              } else {
+                puts $gwname1
+                if {($type == "LanInterface") && ($connection == "0" )} then {
+                  set dutycycle -1
+                  puts "Set DC to $dutycycle"
+                }
+                # Wird der Gateway Name nachtr√§glich gesetzt, Systemvariable mit Seriennummer umbenennen
+                append rega_cmd_rename_sv "string svName = '$gwnoname';string svNewName = '$gwname1';object svObj = dom.GetObject(ID_SYSTEM_VARIABLES).Get(svName);if (svObj){dom.GetObject(ID_SYSTEM_VARIABLES).Get(svName).Name(svNewName);dom.RTUpdate(true)};"
+                rega_script $rega_cmd_rename_sv
+                # Wenn ein Gateway Name eingetragen wurde, wird dieser angehangen z.B. "DutyCycle-OG1"
+                append rega_cmd_create_sv "string svName = '$gwname1';object svObj  = dom.GetObject(ID_SYSTEM_VARIABLES).Get(svName);if (!svObj){object svObjects = dom.GetObject(ID_SYSTEM_VARIABLES);svObj = dom.CreateObject(OT_VARDP);svObjects.Add(svObj.ID());svObj.Name(svName);svObj.ValueType(ivtFloat);svObj.ValueSubType(istGeneric);svObj.DPInfo('DutyCycle Gateway');svObj.ValueUnit('%');svObj.ValueMin(-100);svObj.ValueMax(100);svObj.State(0);svObj.Internal(false);svObj.Visible(true);dom.RTUpdate(true);}"
+                rega_script $rega_cmd_create_sv
+                # DutyCycle Variable aktualisieren
+                append rega_cmd "dom.GetObject(ID_SYSTEM_VARIABLES).Get('$gwname1').State('$dutycycle');"
+                rega_script $rega_cmd
+                # DutyCycle System-Log Meldung erzeugen sofern DC gr√∂√üer 80%
+                if {$dutycycle >= "80"} {
+                  exec logger -t dutycycle -p info "$gwname1 / FW: $fw / DC: $dutycycle %"
+                }
+              }
             }
+          }
         }
       }
     }
+
+# Section Wired-Gateway
+puts "--------------------"
+set fp [open "/usr/local/etc/config/hs485d.conf" r]
+set filecontent [read $fp]
+set input_list [split $filecontent "\n"]
+set wiredList [lsearch -exact $input_list "\[Interface 0\]"]
+close $fp
+set wiredgateway ""
+set wiredvarName "Wired-Status"
+
+# Sofern kein Wired-Gateway eingebunden, wird nichts gemacht
+if { $wiredList == -1 } then {
+  puts "Wired: no"
   }
+
+if { $wiredList > -1 } then {
+    puts "Wired: yes"
+    # Pr√ºfen ob Wired Gateway verbunden ist und ggf. Connection Status auf 0 setzen
+    if { [catch {set wiredgateway [xmlrpc http://127.0.0.1:2000/ getLGWStatus]} fid] } {
+      set connection "diconnected"
+      puts "Gateway $connection"
+      #puts "Fehlermeldung: $fid"
+      # Pr√ºfen ob Wired-Status Systemvariable existiert und ggf. anlegen
+      append rega_cmd_create_sv "string svName='Wired-Status';object svObj=dom.GetObject(ID_SYSTEM_VARIABLES).Get(svName);if (!svObj){object svObjects=dom.GetObject(ID_SYSTEM_VARIABLES);svObj=dom.CreateObject(OT_VARDP);svObjects.Add(svObj.ID());svObj.Name(svName);svObj.ValueType(ivtBinary);svObj.ValueSubType(istBool);svObj.ValueName0('offline');svObj.ValueName1('online');svObj.State(true);svObj.DPInfo('Wired-Status');svObj.ValueUnit('');dom.RTUpdate(true);}"
+      rega_script $rega_cmd_create_sv
+      # Wired-Status Variable aktualisieren
+      append rega_cmd "dom.GetObject(ID_SYSTEM_VARIABLES).Get('$wiredvarName').State(false);"
+      rega_script $rega_cmd
+      } else {
+        set connection "1"
+        set wiredgateway [xmlrpc http://127.0.0.1:2000/ getLGWStatus]
+      }
+    }
+
+# Sofern getLGWStatus verf√ºgbar, Connetion Status direkt √ºber getLGWStatus abfragen
+set lines [split [string map [list "{CO" "\x00"] $wiredgateway] "\x00"]
+if { $connection == "1" } {
+  foreach line $lines {
+    regexp "CONNECTED (.?) " $line dummy connection1
+    # Pr√ºfen ob Wired-Status Systemvariable existiert und ggf. anlegen
+    append rega_cmd_create_sv "string svName='Wired-Status';object svObj=dom.GetObject(ID_SYSTEM_VARIABLES).Get(svName);if (!svObj){object svObjects=dom.GetObject(ID_SYSTEM_VARIABLES);svObj=dom.CreateObject(OT_VARDP);svObjects.Add(svObj.ID());svObj.Name(svName);svObj.ValueType(ivtBinary);svObj.ValueSubType(istBool);svObj.ValueName0('offline');svObj.ValueName1('online');svObj.State(true);svObj.DPInfo('Wired-Status');svObj.ValueUnit('');dom.RTUpdate(true);}"
+    rega_script $rega_cmd_create_sv
+    # Wired-Status Variable aktualisieren
+    append rega_cmd "dom.GetObject(ID_SYSTEM_VARIABLES).Get('$wiredvarName').State(true);"
+    rega_script $rega_cmd
+    puts "Gateway connected"
+  }
+}


### PR DESCRIPTION
This patch will fix the following issues:
- Double runs or logging outputs if more than one Gateway in use
- System variable is not created because another object with the same name already exists (now use ID_SYSTEM_VARIABLES)
- Too many logging entries (now only create a entry if DC equal or greater 80 %)
- Removes unused parts / Code cleaned up

This patch will add:
- Checking if Wired-Gateway in use, then create a system variable named "Wired-Status" with the states "online/offline". This will allow as with the RF Gatways to respond via central program if the Network connection of the Wired-Gateway was disconnected