### PR TITLE
The fstab should have an fsck (if needed)

### DIFF
--- a/buildroot-external/overlay/base/etc/fstab
+++ b/buildroot-external/overlay/base/etc/fstab
@@ -11,5 +11,5 @@ sysfs           /sys           sysfs    defaults                                
 tmpfs           /var           tmpfs    defaults,noatime,size=50%                0      0
 tmpfs           /media         tmpfs    defaults,noatime                         0      0
 debugfs         /sys/kernel/debug debugfs noauto                                 0      0
-LABEL=userfs    /usr/local     ext4     defaults,noatime,nodiratime,rw,data=journal         0      0
+LABEL=userfs    /usr/local     ext4     defaults,noatime,nodiratime,rw,data=journal         0      2
 LABEL=bootfs    /boot          vfat     defaults,ro                              0      0


### PR DESCRIPTION
According to the manpage of fstab, setting the pass to 2 should have fsck check the filesystem after other filesystems.
Setting pass to zero means fsck will not check this filesystem.

I have successfully tested this on my Raspberry Pi as it previously had issues when losing power and would require me to manually check the userfs filesystem and repair errors. After setting pass to 2 it didn't require that any more.