### PR TITLE
disable automatic update of DutyCycle variables created by updateDCVa…

### DIFF
--- a/buildroot-external/overlay/base-raspmatic/bin/updateDCVars.tcl
+++ b/buildroot-external/overlay/base-raspmatic/bin/updateDCVars.tcl
@@ -27,6 +27,12 @@
 load tclrpc.so
 load tclrega.so
 
+set NODCVARS_FILE {/etc/config/NoUpdateDCVars}
+if { [file exists $NODCVARS_FILE] == 1} {
+  puts "NoUpdateDCVars file exists. Exiting."
+  exit
+}
+
 set CONFIG_FILE {/usr/local/etc/config/rfd.conf}
 set gateways [xmlrpc http://127.0.0.1:2001/ listBidcosInterfaces]
 


### PR DESCRIPTION
…rs.tcl by putting a file name "NoUpdateDCVars" to /etc/config