### PR TITLE
Change TMP dir for createBackup.sh

### DIFF
--- a/buildroot-external/overlay/base-raspmatic/bin/createBackup.sh
+++ b/buildroot-external/overlay/base-raspmatic/bin/createBackup.sh
@@ -27,10 +27,7 @@ if [ -n "${1}" ]; then
 fi
 
 # make sure BACKUPDIR exists
-if [ -d "/media/usb0" ];
-	then TMPDIR=$(mktemp -d -p /media/usb0)
-	else TMPDIR=$(mktemp -d -p /usr/local/tmp)
-fi
+TMPDIR=$(mktemp -d -p ${BACKUPDIR})
 
 # make sure ReGaHSS saves its current settings
 echo 'load tclrega.so; rega system.Save()' | tclsh 2>&1 >/dev/null

--- a/buildroot-external/overlay/base-raspmatic/bin/createBackup.sh
+++ b/buildroot-external/overlay/base-raspmatic/bin/createBackup.sh
@@ -27,7 +27,10 @@ if [ -n "${1}" ]; then
 fi
 
 # make sure BACKUPDIR exists
-TMPDIR=$(mktemp -d -p /usr/local/tmp)
+if [ -d "/media/usb0" ];
+	then TMPDIR=$(mktemp -d -p /media/usb0)
+	else TMPDIR=$(mktemp -d -p /usr/local/tmp)
+fi
 
 # make sure ReGaHSS saves its current settings
 echo 'load tclrega.so; rega system.Save()' | tclsh 2>&1 >/dev/null


### PR DESCRIPTION
If a USB Drive is mounted, the root of this Device will be used as TEMP dir otherwise /usr/local/tmp is used.

This change is made to improve SD-Card lifetime due to daily Backups over crondBackup.sh
This is my first try for a pull request, so be kindly if something is wrong :)