### PR TITLE
Avoid buffer overflow in case of writing escaped characters inside mod_authn_rega

### DIFF
--- a/buildroot-external/patches/lighttpd/0001-rega-auth.patch
+++ b/buildroot-external/patches/lighttpd/0001-rega-auth.patch
@@ -118,7 +118,7 @@
 +
 +  int m = 0;
 +  //user
-+  for(int i = 0 ; i < lengthUser && m <= 1023; i++) {
++  for(int i = 0 ; i < lengthUser && m <= 1022; i++) {
 +    const char c = user[i];
 +    if(c == '\\') {
 +      msg[m] = '\\';
@@ -139,7 +139,7 @@
 +  msg[m] = ':';
 +  m++;
 +  //pass
-+  for(int i = 0; i < lengthPass && m <= 1023; i++) {
++  for(int i = 0; i < lengthPass && m <= 1022; i++) {
 +    const char c = pass[i];
 +    if(c == '\\') {
 +      msg[m] = '\\';

--- a/buildroot-external/patches/lighttpd/0001-rega-auth/lighttpd/src/mod_authn_rega.c
+++ b/buildroot-external/patches/lighttpd/0001-rega-auth/lighttpd/src/mod_authn_rega.c
@@ -93,7 +93,7 @@ int checkAuth(int port, const char* user, const char* pass) {
 
   int m = 0;
   //user
-  for(int i = 0 ; i < lengthUser && m <= 1023; i++) {
+  for(int i = 0 ; i < lengthUser && m <= 1022; i++) {
     const char c = user[i];
     if(c == '\\') {
       msg[m] = '\\';
@@ -114,7 +114,7 @@ int checkAuth(int port, const char* user, const char* pass) {
   msg[m] = ':';
   m++;
   //pass
-  for(int i = 0; i < lengthPass && m <= 1023; i++) {
+  for(int i = 0; i < lengthPass && m <= 1022; i++) {
     const char c = pass[i];
     if(c == '\\') {
       msg[m] = '\\';


### PR DESCRIPTION
The for loop checks, that a single character fits inside the buffer. But in case of character escaping there will be added two characters inside the loop so that the buffer could be exceed by one.