### PR TITLE
Protection against XSS by CSP & mask ReGaHss Servername

### DIFF
--- a/buildroot-external/overlay/base/etc/lighttpd/conf.d/setenv.conf
+++ b/buildroot-external/overlay/base/etc/lighttpd/conf.d/setenv.conf
@@ -1,4 +1,10 @@
+setenv.set-response-header = (
+  "Server" => "Server"
+)
+
 setenv.add-response-header = (
+  "Content-Security-Policy" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com;style-src 'unsafe-inline' 'self';img-src 'self' data:",
+  "X-Content-Security-Policy" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com;style-src 'unsafe-inline' 'self';img-src 'self' data:",
   "X-Frame-Options" => "SAMEORIGIN",
   "X-Content-Type-Options" => "nosniff",
   "X-XSS-Protection" => "1; mode=block",


### PR DESCRIPTION
1. the setenv.set-response-header part will overwrite the possibly provided ReGaHss Server name on Lighttpd controlled ports
The HTTP response header will not longer contain ```Server: ise GmbH HTTP-Server v2.0``` --> it becomes ```Server: Server```
If a system is available on open port 80 by portforwarding, it is not longer identifiable by this special server name
Currently there are 8303 open HomeMatic systems listed: https://www.shodan.io/search?query=ise+GmbH+HTTP-Server+v2.0
It's (a little bit) harder for the attacker to find a HomeMatic system, if the Server HTTP header is obfuscated.

2. The CSP setting protects against XSS attacks. It needs to allow remote host ```*.homematic.com``` to be able to load version check java script from http://ccu3-update.homematic.com/firmware/download?cmd=js_check_version&........
You may adjust the host name for RaspberryMatic update check, too.