### PR TITLE
hotfix: all Add-On URLs without CSP settings

### DIFF
--- a/buildroot-external/overlay/base/etc/lighttpd/conf.d/setenv.conf
+++ b/buildroot-external/overlay/base/etc/lighttpd/conf.d/setenv.conf
@@ -2,10 +2,9 @@ setenv.set-response-header = (
   "Server" => ""
 )
 
-setenv.add-response-header = (
-  "Content-Security-Policy" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com https://gitcdn.xyz ;style-src 'unsafe-inline' 'self';img-src 'self' data: ;connect-src 'self' http://*:8088",
-  "X-Content-Security-Policy" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com https://gitcdn.xyz ;style-src 'unsafe-inline' 'self';img-src 'self' data: ;connect-src 'self' http://*:8088",
-  "X-WebKit-CSP" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com https://gitcdn.xyz ;style-src 'unsafe-inline' 'self';img-src 'self' data: ;connect-src 'self' http://*:8088",
+# Location based HTTP headers, HowTo by https://redmine.lighttpd.net/boards/2/topics/6541
+# This is the common header added to all responses
+var.common-response-headers = (
   "X-Frame-Options" => "SAMEORIGIN",
   "X-Content-Type-Options" => "nosniff",
   "X-XSS-Protection" => "1; mode=block",
@@ -14,3 +13,16 @@ setenv.add-response-header = (
   "X-Permitted-Cross-Domain-Policies" => "none",
   "Referrer-Policy" => "no-referrer"
 )
+
+# hotfix: all Add-Ons will be without CSP until it will be tested and working for all
+$HTTP["url"] =~ "^/addons/.*" {
+  setenv.add-response-header = var.common-response-headers
+} else {
+# all non Add-Ons will keep with strict additional CSP setting
+  setenv.add-response-header = var.common-response-headers
+  setenv.add-response-header += (
+    "Content-Security-Policy" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com https://gitcdn.xyz ;style-src 'unsafe-inline' 'self';img-src 'self' data: ;connect-src 'self' http://*:8088",
+    "X-Content-Security-Policy" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com https://gitcdn.xyz ;style-src 'unsafe-inline' 'self';img-src 'self' data: ;connect-src 'self' http://*:8088",
+    "X-WebKit-CSP" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com https://gitcdn.xyz ;style-src 'unsafe-inline' 'self';img-src 'self' data: ;connect-src 'self' http://*:8088"
+  )
+}

--- a/buildroot-external/overlay/base/etc/lighttpd/conf.d/setenv.conf
+++ b/buildroot-external/overlay/base/etc/lighttpd/conf.d/setenv.conf
@@ -21,8 +21,8 @@ $HTTP["url"] =~ "^/addons/.*" {
 # all non Add-Ons will keep with strict additional CSP setting
   setenv.add-response-header = var.common-response-headers
   setenv.add-response-header += (
-    "Content-Security-Policy" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com https://gitcdn.xyz ;style-src 'unsafe-inline' 'self';img-src 'self' data: ;connect-src 'self' http://*:8088",
-    "X-Content-Security-Policy" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com https://gitcdn.xyz ;style-src 'unsafe-inline' 'self';img-src 'self' data: ;connect-src 'self' http://*:8088",
-    "X-WebKit-CSP" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com https://gitcdn.xyz ;style-src 'unsafe-inline' 'self';img-src 'self' data: ;connect-src 'self' http://*:8088"
+    "Content-Security-Policy" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com *.homematic.com:8443 https://gitcdn.xyz ;style-src 'unsafe-inline' 'self';img-src 'self' data: ;connect-src 'self' http://*:8088",
+    "X-Content-Security-Policy" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com *.homematic.com:8443 https://gitcdn.xyz ;style-src 'unsafe-inline' 'self';img-src 'self' data: ;connect-src 'self' http://*:8088",
+    "X-WebKit-CSP" => "default-src 'self';frame-ancestors 'self';script-src 'unsafe-inline' 'unsafe-eval' 'self' *.homematic.com *.homematic.com:8443 https://gitcdn.xyz ;style-src 'unsafe-inline' 'self';img-src 'self' data: ;connect-src 'self' http://*:8088"
   )
 }


### PR DESCRIPTION
The new CSP setting was not tested togehter with Add-Ons and it breaks they usage now :-(
This is a hotfix (template) for RaspberryMatic 3.45.7.20190504 which will put the CSP settings only to WebGUI URL paths.
All Add-Ons are excluded at the moment with that updated setting.
But the final version should set as much as possible Add-Ons with CSP (and maybe they additonal whitelists)

@hobbyquaker just FYI what need to be changed because of https://homematic-forum.de/forum/viewtopic.php?f=77&t=50590
