### PR TITLE
Explicit detection of HmIP-RFUSB-TK

### DIFF
--- a/buildroot-external/overlay/base/etc/init.d/S11InitRFHardware
+++ b/buildroot-external/overlay/base/etc/init.d/S11InitRFHardware
@@ -284,6 +284,10 @@ query_rf_parameters() {
       RF_VERSION=$(echo ${RF_INFO} | sed -n 's/.*Application version = \([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')
       RF_ADDRESS=$(echo ${RF_INFO} | sed -n 's/.*Radio address = \([0-9A-F]\{6\}\).*/0x\1/p')
 
+      if [[ "${RF_SGTIN}" =~ "3014f5ac94" ]]; then
+        HM_HMIP_DEV="HMIP-RFUSB-TK"
+      fi
+
       HM_HMIP_SERIAL=${RF_SERIAL}
       HM_HMIP_VERSION=${RF_VERSION}
       HM_HMIP_ADDRESS=${RF_ADDRESS}


### PR DESCRIPTION
Da die Telekom Version des Sticks keine Firmware Updates eingespielt bekommen kann und es Anzeichen gibt, dass der auch beim einem Wechsel des Funkmoduls Probleme beim Rekeying über die eQ-3 Server gibt, macht es imho Sinn, den Stick explizit zu erkennen.
Durch die explizite Erkennung wird dann auch gleich der Versuch des Firmware Updates unterlassen, weil dort die Prüfung auf den HmIP-RFUSB (ohne TK) drin ist, welche dann bei der TK Version nicht mehr greift.