### PR TITLE
Mitigate another RCE possibility

### DIFF
--- a/buildroot-external/overlay/base/etc/lighttpd/conf.d/proxy.conf
+++ b/buildroot-external/overlay/base/etc/lighttpd/conf.d/proxy.conf
@@ -3,8 +3,15 @@
 #-----------
 $SERVER["socket"] == ":80" {
   server.document-root = server_root
+  # Deny external access to such URLs, allow localhost access within HM scripts only
   $HTTP["url"] =~ "^/.*\.(exe|oxml|hssml).*" {
     $HTTP["remoteip"] !~ "^(127\.0\.0\.1|::ffff:127\.0\.0\.1|::1)$" {
+      url.access-deny = ( "" )
+    }
+  }
+  # Mitigate another Remote Code Execution possibility, access to Root URL only allowed with HTTP GET method
+  $HTTP["url"] =~ "^/$" {
+    $HTTP["request-method"] !~ "^(GET)$" {
       url.access-deny = ( "" )
     }
   }
@@ -18,8 +25,15 @@ $SERVER["socket"] == ":80" {
 $SERVER["socket"] == "[::]:80" {
   server.document-root = server_root
   server.use-ipv6 = "enable"
+  # Deny external access to such URLs, allow localhost access within HM scripts only
   $HTTP["url"] =~ "^/.*\.(exe|oxml|hssml).*" {
     $HTTP["remoteip"] !~ "^(127\.0\.0\.1|::ffff:127\.0\.0\.1|::1)$" {
+      url.access-deny = ( "" )
+    }
+  }
+  # Mitigate another Remote Code Execution possibility, access to Root URL only allowed with HTTP GET method
+  $HTTP["url"] =~ "^/$" {
+    $HTTP["request-method"] !~ "^(GET)$" {
       url.access-deny = ( "" )
     }
   }
@@ -37,8 +51,15 @@ $SERVER["socket"] == "[::]:80" {
 $SERVER["socket"] == ":443" {
   server.document-root = server_root
   include "/etc/lighttpd/conf.d/sslsettings.conf"
+  # Deny external access to such URLs, allow localhost access within HM scripts only
   $HTTP["url"] =~ "^/.*\.(exe|oxml|hssml).*" {
     $HTTP["remoteip"] !~ "^(127\.0\.0\.1|::ffff:127\.0\.0\.1|::1)$" {
+      url.access-deny = ( "" )
+    }
+  }
+  # Mitigate another Remote Code Execution possibility, access to Root URL only allowed with HTTP GET method
+  $HTTP["url"] =~ "^/$" {
+    $HTTP["request-method"] !~ "^(GET)$" {
       url.access-deny = ( "" )
     }
   }
@@ -53,8 +74,15 @@ $SERVER["socket"] == "[::]:443" {
   server.document-root = server_root
   server.use-ipv6 = "enable"
   include "/etc/lighttpd/conf.d/sslsettings.conf"
+  # Deny external access to such URLs, allow localhost access within HM scripts only
   $HTTP["url"] =~ "^/.*\.(exe|oxml|hssml).*" {
     $HTTP["remoteip"] !~ "^(127\.0\.0\.1|::ffff:127\.0\.0\.1|::1)$" {
+      url.access-deny = ( "" )
+    }
+  }
+  # Mitigate another Remote Code Execution possibility, access to Root URL only allowed with HTTP GET method
+  $HTTP["url"] =~ "^/$" {
+    $HTTP["request-method"] !~ "^(GET)$" {
       url.access-deny = ( "" )
     }
   }


### PR DESCRIPTION
As communicated the access to root URL should be allowed for HTTP GET method only.
This will mitigate the proven RemoteCodeExecution, otherwise the next check
```$HTTP["url"] !~ "^/(config/)|(upnp/)|(webui/)|(ise/)|(api/)|(tools/)|(pda)|(pages/jpages)|(addons).*" {```
will apply, because "!~" means "expression not match" and finally the request with its payload is forwarded to ReGa process

Disclaimer:
The start page of WebUI is accessible on ```http://1.2.3.4``` and ```http://1.2.3.4/``` in browser by common HTTP GET request and will redirect to login page. All other HTTP Methods are blocked.
The check could be enhanced by checking against localhost vs. remote IP.
I did not check any negative impact to existing external tools, AddOns nor scripts.

<!--

Requirements for Contributing
=============================

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Make sure you have read and understood the CONTRIBUTING.md file in the top-level directory with information related to licensing requirments, etc. In sort: Everything you contribute have to be able to be (re)licensed under the Apache 2.0 license to be able to be contributed to RaspberryMatic

-->

### Description

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Related Issue

<!--- Please link to an open issue here: -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in RaspberryMatic's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

### Contributing checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** and **LICENSE** document.
- [ ] I fully agree to distribute my changes under Apache 2.0 license.

<!--

Please read and understand the CONTRIBUTING.md file in the top-level directory and also the Apache 2.0 licensing terms. Please make sure to state any licensing conflicts you might have identified / found during development of your pull request. Please also understand that anything you contribute MUST be (re)licenseable under the Apache 2.0 license or otherwise we can not accept your PR for integration.

If you don't have any licensing conflicts please state "Not applicable" or "N/A" which certifies that you have checked the (re)licensing terms and that you are agree with distributing your changes under the Apache 2.0 license

-->
