### PR TITLE
Fixed creation of default sysvars in case no radio module was connect…

### DIFF
--- a/buildroot-external/patches/occu/0072-WebUI-Fix-hm_autoconf.patch
+++ b/buildroot-external/patches/occu/0072-WebUI-Fix-hm_autoconf.patch
@@ -1,13 +1,412 @@
 --- occu/WebUI/bin/hm_autoconf.orig
 +++ occu/WebUI/bin/hm_autoconf
-@@ -499,7 +499,9 @@
-         string ifaces;
-         foreach(if_id, dom.GetObject(ID_INTERFACES).EnumUsedIDs()){
-             object o=dom.GetObject(if_id);
--            ifaces = ifaces # if_id # " {" # o.InterfaceUrl() # " " # o.Name() # "} ";
-+            if(o.InterfaceUrl() != "") {
-+                ifaces = ifaces # if_id # " {" # o.InterfaceUrl() # " " # o.Name() # "} ";
-+            }
+@@ -41,9 +41,9 @@
+ 
+     load tclrega.so
+     load tclrpc.so
+-    
++
+     # List of default functions (german "Gewerke") that will be automatically generated
+-     set FUNCTIONLIST {
++    array set FUNCTIONLIST {
+         LIGHT           funcLight
+         HEATING         funcHeating
+         CLIMATECONTROL  funcClimateControl
+@@ -55,22 +55,7 @@
+         CENTRAL         funcCentral
+         ENERGY          funcEnergy
+     }
+-   
+-    # List of default rooms that will be automatically generated
+-    set ROOMLIST {
+-        "roomLivingRoom"
+-        "roomKitchen"
+-        "roomBedroom"
+-        "roomChildrensRoom1"
+-        "roomChildrensRoom2"
+-        "roomOffice"
+-        "roomBathroom"
+-        "roomGarage"
+-        "roomHWR"
+-        "roomGarden"
+-        "roomTerrace"
+-    }
+-    
++
+     # Mapping of channel type to default function for the channel
+     array set CHANNEL_FUNCTIONS {
+         BLIND                   LIGHT
+@@ -118,6 +103,21 @@
+         rega "dom.GetObject($dev_id).ReadyConfig(true);"
+         puts "ReadyConfig($dev_id)"
+     }
++
++    proc conf_device_HmIP-RCV-50 { url dev_id desc_var } {
++        rega "dom.GetObject($dev_id).ReadyConfig(true);"
++        puts "ReadyConfig($dev_id)"
++    }
++
++    proc conf_device_RPI-RF-MOD { url dev_id desc_var } {
++        rega "dom.GetObject($dev_id).ReadyConfig(true);"
++        puts "ReadyConfig($dev_id)"
++    }
++	
++	proc conf_device_HmIP-CCU3 { url dev_id desc_var } {
++        rega "dom.GetObject($dev_id).ReadyConfig(true);"
++        puts "ReadyConfig($dev_id)"
++    }
+     
+     proc conf_device_HM-CCU-1 { url dev_id desc_var } {
+         rega "dom.GetObject($dev_id).ReadyConfig(true);"
+@@ -136,7 +136,6 @@
+     
+     proc conf_value_WEATHER.RAIN_COUNTER { url ch_id ch_desc_var value_desc_var} {
+         create_rain_calculation $ch_id
+-        
+     }
+     
+     proc conf_value_DISPLAY.SERVICE_COUNT { url ch_id ch_desc_var value_desc_var} {
+@@ -147,90 +146,6 @@
+         create_sysvar_to_value_prg $ch_id ALARM_COUNT 40 "Alarmmeldungen anzeigen"
+     }
+     
+-    proc create_objects {collection enum_type names} {
+-        set ids [rega "dom.GetObject($collection).EnumIDs()"]
+-        set i 0
+-        foreach name $names {
+-            set id [lindex $ids $i]
+-            if { "$id" == "" } {
+-                #create object first
+-                set script "\
+-                    var new_id = -1;\n\
+-                    object o = dom.CreateObject( OT_ENUM, \"new object\" );\n\
+-                    if( o ) \{\n\
+-                        o.EnumType( $enum_type );\n\
+-                        boolean res = dom.GetObject( $collection ).Add( o );\n\
+-                        if( res ) \{\n\
+-                            new_id = o.ID();\n\
+-                        \} else \{\n\
+-                            dom.DeleteObject( o.ID() );\n\
+-                        \}\n\
+-                    \}\
+-                "
+-                #puts "Executing $script"
+-                array set r [rega_script $script]
+-                set id $r(new_id)
+-                if { $id < 0 } {
+-                    puts "Error creating object"
+-                }
+-            }
+-            rega "dom.GetObject($id).Name(\"[lindex $names $i]\")"
+-            rega "dom.GetObject($id).Enabled(true)"
+-            incr i
+-        }
+-        return [lsort [rega "dom.GetObject($collection).EnumUsedIDs()"]]
+-    }
+-    
+-    proc create_functions {} {
+-        global FUNCTIONLIST
+-        for { set i 1 } { $i < [llength $FUNCTIONLIST] } { incr i 2 } {
+-            lappend names [lindex $FUNCTIONLIST $i]
+-        }
+-        return [create_objects ID_FUNCTIONS etFunction $names]
+-    }
+-    
+-    proc create_rooms {} {
+-        global ROOMLIST
+-        return [create_objects ID_ROOMS etRoom $ROOMLIST]
+-    }
+-    
+-    proc create_sysvars {} {
+-        rega_script {
+-            object sv=dom.CreateObject(OT_ALARMDP, "${sysVarAlarmZone1}");
+-            dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
+-            sv.DPInfo("${sysVarAlarmZone1Msg}");
+-            sv.ValueUnit("");
+-            sv.ValueType( ivtBinary );
+-            sv.ValueSubType( istAlarm );
+-            sv.ValueName1("${sysVarAlarmZone1Triggered}");
+-            sv.ValueName0("${sysVarAlarmZone1NotTriggered}");
+-            sv.AlType(atSystem);
+-            sv.AlArm(true);            
+-            
+-            sv=dom.GetObject(ID_PRESENT);
+-            dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
+-            sv.Name("${sysVarPresence}");
+-            sv.DPInfo("${sysVarPresenceMsg}");
+-            sv.ValueUnit("");
+-            sv.ValueName1("${sysVarPresencePresent}");
+-            sv.ValueName0("${sysVarPresenceNotPresent}");
+-            
+-            sv=dom.GetObject(40);
+-            dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
+-            sv.Name("${sysVarAlarmMessages}");
+-            sv.DPInfo("${sysVarAlarmMessagesCount}");
+-            sv.Internal(0);
+-            
+-            sv=dom.GetObject(41);
+-            dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
+-            sv.Name("${sysVarServiceMessages}");
+-            sv.DPInfo("${sysVarServiceMessagesCount}");
+-            sv.Internal(0);
+-            
+-        }
+-    }
+-    
+-    
+     proc create_sysvar_to_value_prg {ch_id value sv_id prg_name} {
+         set script "string ch_id=\"$ch_id\";\nstring value_name=\"$value\";\nstring sv_id=$sv_id;\nstring prg_name=\"$prg_name\";\n"
+         append script {
+@@ -516,35 +431,22 @@
+                 }
+             }
          }
-         string dev_id;
-         string devs;
+-        string functions=dom.GetObject(ID_FUNCTIONS).EnumUsedIDs();
+-        string rooms=dom.GetObject(ID_ROOMS).EnumUsedIDs();
+-        string sysvars=dom.GetObject(ID_SYSTEM_VARIABLES).EnumUsedIDs();
++        string func_id;
++        string functions;
++        foreach (func_id, dom.GetObject(ID_FUNCTIONS).EnumUsedIDs()){
++            functions = functions # " {" # dom.GetObject(func_id).Name() # "} " # func_id;
++        }
+     }]
+     
+     array set ifmap $result(ifaces)
+     array set devmap $result(devs)
+-    
+-    set ise_functions [lsort $result(functions)]
+-    if { [llength $ise_functions] == 0 } {
+-        puts "No functions defined, creating default functions"
+-        set ise_functions [create_functions]
+-    }
+-    
+-    if { [llength $result(rooms)] == 0 } { 
+-        puts "No rooms defined, creating default rooms"
+-        create_rooms
+-    }
+-    
+-    if { [llength $result(sysvars)] == 0 } {
+-        puts "No system variables defined, creating default system variables"
+-        create_sysvars
+-    }
+-    
+-    set i 0
+-    foreach function_id $ise_functions {
+-        if { $i >= [llength $FUNCTIONLIST] } break;
+-        set FUNCTIONMAP([lindex $FUNCTIONLIST $i]) $function_id
+-        incr i 2
++
++    array set ise_functions $result(functions)
++
++    foreach func [array names FUNCTIONLIST] {
++        if {[info exists ise_functions($FUNCTIONLIST($func))]} {
++            set FUNCTIONMAP($func) $ise_functions($FUNCTIONLIST($func))
++        }
+     }
+ 
+     # We need a catch because OSRAM Lightify causes an error (/tmp/hm_autoconf_xxx.log) because a list must have an even number of elements.
+@@ -577,13 +479,24 @@
+               array_clear ch_descr
+               array set ch_descr [xmlrpc $url getDeviceDescription $ch_address]
+               if [info exist DEVICE_FUNCTIONS($dev_descr(TYPE))] {
+-                  catch {
+-                      rega "dom.GetObject($FUNCTIONMAP($DEVICE_FUNCTIONS($dev_descr(TYPE)))).Add($ise_ch_id)"
++                  if [info exist FUNCTIONMAP($DEVICE_FUNCTIONS($dev_descr(TYPE)))] {
++                      catch {
++                          rega "dom.GetObject($FUNCTIONMAP($DEVICE_FUNCTIONS($dev_descr(TYPE)))).Add($ise_ch_id)"
++                      }
+                   }
+               }
+               if [info exist CHANNEL_FUNCTIONS($ch_descr(TYPE))] {
+-                  catch {
+-                      rega "dom.GetObject($FUNCTIONMAP($CHANNEL_FUNCTIONS($ch_descr(TYPE)))).Add($ise_ch_id)"
++                  if [info exist FUNCTIONMAP($CHANNEL_FUNCTIONS($ch_descr(TYPE)))] {
++                      catch {
++                          rega "dom.GetObject($FUNCTIONMAP($CHANNEL_FUNCTIONS($ch_descr(TYPE)))).Add($ise_ch_id)"
++                      }
++                  }
++              }
++              if { [string equal $ch_descr(PARENT_TYPE) "HmIP-RCV-50"] == 1 } {
++                  if [info exist FUNCTIONMAP(CENTRAL)] {
++                      catch {
++                          rega "dom.GetObject($FUNCTIONMAP(CENTRAL)).Add($ise_ch_id)"
++                      }
+                   }
+               }
+               set procname "conf_channel_$ch_descr(TYPE)"
+--- occu/WebUI/bin/hm_startup.orig
++++ occu/WebUI/bin/hm_startup
+@@ -1,27 +1,7 @@
+ #!/bin/tclsh
+ 
+-#*******************************************************************************
+-#* hm_startup
+-#* Wird beim Starten von ise ReGa ausgeführt. 
+-#*
+-#* Aufgaben:
+-#*   - sucht fertig konfigurierte Geräte und setzt deren Kanäle ebenfalls auf 
+-#*     "fertig konfiguriert"
+-#*
+-#* Autor      : Falk Werner
+-#* Erstellt am: 23.07.2008
+-#*******************************************************************************
+-
+-################################################################################
+-# Module                                                                       #
+-################################################################################
+-
+ load tclrega.so
+ 
+-################################################################################
+-# Prozeduren                                                                   #
+-################################################################################
+-
+ #*******************************************************************************
+ #* Sucht fertig konfigurierte Geräte und setzt deren Kanäle auf "fertig 
+ #* konfiguriert".
+@@ -37,8 +17,145 @@
+   }
+ }
+ 
++# List of default functions (german "Gewerke") that will be automatically generated
++set FUNCTIONLIST {
++  "funcLight"
++  "funcHeating"
++  "funcClimateControl"
++  "funcWeather"
++  "funcEnvironment"
++  "funcSecurity"
++  "funcLock"
++  "funcButton"
++  "funcCentral"
++  "funcEnergy"
++}
++
++# List of default rooms that will be automatically generated
++set ROOMLIST {
++  "roomLivingRoom"
++  "roomKitchen"
++  "roomBedroom"
++  "roomChildrensRoom1"
++  "roomChildrensRoom2"
++  "roomOffice"
++  "roomBathroom"
++  "roomGarage"
++  "roomHWR"
++  "roomGarden"
++  "roomTerrace"
++}
++
++proc create_objects {collection enum_type names} {
++  set ids [rega "dom.GetObject($collection).EnumIDs()"]
++  set i 0
++
++  foreach name $names {
++    set id [lindex $ids $i]
++    if { "$id" == "" } {
++      #create object first
++      set script "\
++        var new_id = -1;\n\
++        object o = dom.CreateObject( OT_ENUM, \"new object\" );\n\
++        if( o ) \{\n\
++          o.EnumType( $enum_type );\n\
++          boolean res = dom.GetObject( $collection ).Add( o );\n\
++          if( res ) \{\n\
++            new_id = o.ID();\n\
++          \} else \{\n\
++            dom.DeleteObject( o.ID() );\n\
++          \}\n\
++        \}\
++        "
++      #puts "Executing $script"
++      array set r [rega_script $script]
++      set id $r(new_id)
++      if { $id < 0 } {
++        puts "Error creating object"
++      }
++    }
++
++    rega "dom.GetObject($id).Name(\"[lindex $names $i]\")"
++    rega "dom.GetObject($id).Enabled(true)"
++    incr i
++  }
++
++  return [lsort [rega "dom.GetObject($collection).EnumUsedIDs()"]]
++}
++
++proc create_default_functions {} {
++  global FUNCTIONLIST
++  return [create_objects ID_FUNCTIONS etFunction $FUNCTIONLIST]
++}
++
++proc create_default_rooms {} {
++  global ROOMLIST
++  return [create_objects ID_ROOMS etRoom $ROOMLIST]
++}
++
++proc create_default_sysvars {} {
++  rega_script {
++    object sv=dom.CreateObject(OT_ALARMDP, "${sysVarAlarmZone1}");
++    dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
++    sv.DPInfo("${sysVarAlarmZone1Msg}");
++    sv.ValueUnit("");
++    sv.ValueType( ivtBinary );
++    sv.ValueSubType( istAlarm );
++    sv.ValueName1("${sysVarAlarmZone1Triggered}");
++    sv.ValueName0("${sysVarAlarmZone1NotTriggered}");
++    sv.AlType(atSystem);
++    sv.AlArm(true);
++
++    sv=dom.GetObject(ID_PRESENT);
++    dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
++    sv.Name("${sysVarPresence}");
++    sv.DPInfo("${sysVarPresenceMsg}");
++    sv.ValueUnit("");
++    sv.ValueName1("${sysVarPresencePresent}");
++    sv.ValueName0("${sysVarPresenceNotPresent}");
++
++    sv=dom.GetObject(40);
++    dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
++    sv.Name("${sysVarAlarmMessages}");
++    sv.DPInfo("${sysVarAlarmMessagesCount}");
++    sv.Internal(0);
++
++    sv=dom.GetObject(41);
++    dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
++    sv.Name("${sysVarServiceMessages}");
++    sv.DPInfo("${sysVarServiceMessagesCount}");
++    sv.Internal(0);
++  }
++}
++
++proc create_default_objects {} {
++  array set result [rega_script {
++    string functions=dom.GetObject(ID_FUNCTIONS).EnumUsedIDs();
++    string rooms=dom.GetObject(ID_ROOMS).EnumUsedIDs();
++    string sysvars=dom.GetObject(ID_SYSTEM_VARIABLES).EnumUsedIDs();
++  }]
++
++  set ise_functions [lsort $result(functions)]
++  if { [llength $ise_functions] == 0 } {
++    puts "No functions defined, creating default functions"
++    create_default_functions
++  }
++
++  if { [llength $result(rooms)] == 0 } {
++    puts "No rooms defined, creating default rooms"
++    create_default_rooms
++  }
++
++  if { [llength $result(sysvars)] == 0 } {
++    puts "No system variables defined, creating default system variables"
++    create_default_sysvars
++  }
++}
++
+ ################################################################################
+ # Einsprungpunkt                                                               #
+ ################################################################################
+ 
+ checkDevices
++create_default_objects
++

--- a/buildroot-external/patches/occu/0072-WebUI-Fix-hm_autoconf/occu/WebUI/bin/hm_autoconf
+++ b/buildroot-external/patches/occu/0072-WebUI-Fix-hm_autoconf/occu/WebUI/bin/hm_autoconf
@@ -41,9 +41,9 @@ if { [catch {
 
     load tclrega.so
     load tclrpc.so
-    
+
     # List of default functions (german "Gewerke") that will be automatically generated
-     set FUNCTIONLIST {
+    array set FUNCTIONLIST {
         LIGHT           funcLight
         HEATING         funcHeating
         CLIMATECONTROL  funcClimateControl
@@ -55,22 +55,7 @@ if { [catch {
         CENTRAL         funcCentral
         ENERGY          funcEnergy
     }
-   
-    # List of default rooms that will be automatically generated
-    set ROOMLIST {
-        "roomLivingRoom"
-        "roomKitchen"
-        "roomBedroom"
-        "roomChildrensRoom1"
-        "roomChildrensRoom2"
-        "roomOffice"
-        "roomBathroom"
-        "roomGarage"
-        "roomHWR"
-        "roomGarden"
-        "roomTerrace"
-    }
-    
+
     # Mapping of channel type to default function for the channel
     array set CHANNEL_FUNCTIONS {
         BLIND                   LIGHT
@@ -118,6 +103,21 @@ if { [catch {
         rega "dom.GetObject($dev_id).ReadyConfig(true);"
         puts "ReadyConfig($dev_id)"
     }
+
+    proc conf_device_HmIP-RCV-50 { url dev_id desc_var } {
+        rega "dom.GetObject($dev_id).ReadyConfig(true);"
+        puts "ReadyConfig($dev_id)"
+    }
+
+    proc conf_device_RPI-RF-MOD { url dev_id desc_var } {
+        rega "dom.GetObject($dev_id).ReadyConfig(true);"
+        puts "ReadyConfig($dev_id)"
+    }
+	
+	proc conf_device_HmIP-CCU3 { url dev_id desc_var } {
+        rega "dom.GetObject($dev_id).ReadyConfig(true);"
+        puts "ReadyConfig($dev_id)"
+    }
     
     proc conf_device_HM-CCU-1 { url dev_id desc_var } {
         rega "dom.GetObject($dev_id).ReadyConfig(true);"
@@ -136,7 +136,6 @@ if { [catch {
     
     proc conf_value_WEATHER.RAIN_COUNTER { url ch_id ch_desc_var value_desc_var} {
         create_rain_calculation $ch_id
-        
     }
     
     proc conf_value_DISPLAY.SERVICE_COUNT { url ch_id ch_desc_var value_desc_var} {
@@ -146,90 +145,6 @@ if { [catch {
     proc conf_value_DISPLAY.ALARM_COUNT { url ch_id ch_desc_var value_desc_var} {
         create_sysvar_to_value_prg $ch_id ALARM_COUNT 40 "Alarmmeldungen anzeigen"
     }
-    
-    proc create_objects {collection enum_type names} {
-        set ids [rega "dom.GetObject($collection).EnumIDs()"]
-        set i 0
-        foreach name $names {
-            set id [lindex $ids $i]
-            if { "$id" == "" } {
-                #create object first
-                set script "\
-                    var new_id = -1;\n\
-                    object o = dom.CreateObject( OT_ENUM, \"new object\" );\n\
-                    if( o ) \{\n\
-                        o.EnumType( $enum_type );\n\
-                        boolean res = dom.GetObject( $collection ).Add( o );\n\
-                        if( res ) \{\n\
-                            new_id = o.ID();\n\
-                        \} else \{\n\
-                            dom.DeleteObject( o.ID() );\n\
-                        \}\n\
-                    \}\
-                "
-                #puts "Executing $script"
-                array set r [rega_script $script]
-                set id $r(new_id)
-                if { $id < 0 } {
-                    puts "Error creating object"
-                }
-            }
-            rega "dom.GetObject($id).Name(\"[lindex $names $i]\")"
-            rega "dom.GetObject($id).Enabled(true)"
-            incr i
-        }
-        return [lsort [rega "dom.GetObject($collection).EnumUsedIDs()"]]
-    }
-    
-    proc create_functions {} {
-        global FUNCTIONLIST
-        for { set i 1 } { $i < [llength $FUNCTIONLIST] } { incr i 2 } {
-            lappend names [lindex $FUNCTIONLIST $i]
-        }
-        return [create_objects ID_FUNCTIONS etFunction $names]
-    }
-    
-    proc create_rooms {} {
-        global ROOMLIST
-        return [create_objects ID_ROOMS etRoom $ROOMLIST]
-    }
-    
-    proc create_sysvars {} {
-        rega_script {
-            object sv=dom.CreateObject(OT_ALARMDP, "${sysVarAlarmZone1}");
-            dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
-            sv.DPInfo("${sysVarAlarmZone1Msg}");
-            sv.ValueUnit("");
-            sv.ValueType( ivtBinary );
-            sv.ValueSubType( istAlarm );
-            sv.ValueName1("${sysVarAlarmZone1Triggered}");
-            sv.ValueName0("${sysVarAlarmZone1NotTriggered}");
-            sv.AlType(atSystem);
-            sv.AlArm(true);            
-            
-            sv=dom.GetObject(ID_PRESENT);
-            dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
-            sv.Name("${sysVarPresence}");
-            sv.DPInfo("${sysVarPresenceMsg}");
-            sv.ValueUnit("");
-            sv.ValueName1("${sysVarPresencePresent}");
-            sv.ValueName0("${sysVarPresenceNotPresent}");
-            
-            sv=dom.GetObject(40);
-            dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
-            sv.Name("${sysVarAlarmMessages}");
-            sv.DPInfo("${sysVarAlarmMessagesCount}");
-            sv.Internal(0);
-            
-            sv=dom.GetObject(41);
-            dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
-            sv.Name("${sysVarServiceMessages}");
-            sv.DPInfo("${sysVarServiceMessagesCount}");
-            sv.Internal(0);
-            
-        }
-    }
-    
     
     proc create_sysvar_to_value_prg {ch_id value sv_id prg_name} {
         set script "string ch_id=\"$ch_id\";\nstring value_name=\"$value\";\nstring sv_id=$sv_id;\nstring prg_name=\"$prg_name\";\n"
@@ -499,9 +414,7 @@ if { [catch {
         string ifaces;
         foreach(if_id, dom.GetObject(ID_INTERFACES).EnumUsedIDs()){
             object o=dom.GetObject(if_id);
-            if(o.InterfaceUrl() != "") {
-                ifaces = ifaces # if_id # " {" # o.InterfaceUrl() # " " # o.Name() # "} ";
-            }
+            ifaces = ifaces # if_id # " {" # o.InterfaceUrl() # " " # o.Name() # "} ";
         }
         string dev_id;
         string devs;
@@ -518,35 +431,22 @@ if { [catch {
                 }
             }
         }
-        string functions=dom.GetObject(ID_FUNCTIONS).EnumUsedIDs();
-        string rooms=dom.GetObject(ID_ROOMS).EnumUsedIDs();
-        string sysvars=dom.GetObject(ID_SYSTEM_VARIABLES).EnumUsedIDs();
+        string func_id;
+        string functions;
+        foreach (func_id, dom.GetObject(ID_FUNCTIONS).EnumUsedIDs()){
+            functions = functions # " {" # dom.GetObject(func_id).Name() # "} " # func_id;
+        }
     }]
     
     array set ifmap $result(ifaces)
     array set devmap $result(devs)
-    
-    set ise_functions [lsort $result(functions)]
-    if { [llength $ise_functions] == 0 } {
-        puts "No functions defined, creating default functions"
-        set ise_functions [create_functions]
-    }
-    
-    if { [llength $result(rooms)] == 0 } { 
-        puts "No rooms defined, creating default rooms"
-        create_rooms
-    }
-    
-    if { [llength $result(sysvars)] == 0 } {
-        puts "No system variables defined, creating default system variables"
-        create_sysvars
-    }
-    
-    set i 0
-    foreach function_id $ise_functions {
-        if { $i >= [llength $FUNCTIONLIST] } break;
-        set FUNCTIONMAP([lindex $FUNCTIONLIST $i]) $function_id
-        incr i 2
+
+    array set ise_functions $result(functions)
+
+    foreach func [array names FUNCTIONLIST] {
+        if {[info exists ise_functions($FUNCTIONLIST($func))]} {
+            set FUNCTIONMAP($func) $ise_functions($FUNCTIONLIST($func))
+        }
     }
 
     # We need a catch because OSRAM Lightify causes an error (/tmp/hm_autoconf_xxx.log) because a list must have an even number of elements.
@@ -579,13 +479,24 @@ if { [catch {
               array_clear ch_descr
               array set ch_descr [xmlrpc $url getDeviceDescription $ch_address]
               if [info exist DEVICE_FUNCTIONS($dev_descr(TYPE))] {
-                  catch {
-                      rega "dom.GetObject($FUNCTIONMAP($DEVICE_FUNCTIONS($dev_descr(TYPE)))).Add($ise_ch_id)"
+                  if [info exist FUNCTIONMAP($DEVICE_FUNCTIONS($dev_descr(TYPE)))] {
+                      catch {
+                          rega "dom.GetObject($FUNCTIONMAP($DEVICE_FUNCTIONS($dev_descr(TYPE)))).Add($ise_ch_id)"
+                      }
                   }
               }
               if [info exist CHANNEL_FUNCTIONS($ch_descr(TYPE))] {
-                  catch {
-                      rega "dom.GetObject($FUNCTIONMAP($CHANNEL_FUNCTIONS($ch_descr(TYPE)))).Add($ise_ch_id)"
+                  if [info exist FUNCTIONMAP($CHANNEL_FUNCTIONS($ch_descr(TYPE)))] {
+                      catch {
+                          rega "dom.GetObject($FUNCTIONMAP($CHANNEL_FUNCTIONS($ch_descr(TYPE)))).Add($ise_ch_id)"
+                      }
+                  }
+              }
+              if { [string equal $ch_descr(PARENT_TYPE) "HmIP-RCV-50"] == 1 } {
+                  if [info exist FUNCTIONMAP(CENTRAL)] {
+                      catch {
+                          rega "dom.GetObject($FUNCTIONMAP(CENTRAL)).Add($ise_ch_id)"
+                      }
                   }
               }
               set procname "conf_channel_$ch_descr(TYPE)"

--- a/buildroot-external/patches/occu/0072-WebUI-Fix-hm_autoconf/occu/WebUI/bin/hm_startup
+++ b/buildroot-external/patches/occu/0072-WebUI-Fix-hm_autoconf/occu/WebUI/bin/hm_startup
@@ -1,0 +1,161 @@
+#!/bin/tclsh
+
+load tclrega.so
+
+#*******************************************************************************
+#* Sucht fertig konfigurierte Geräte und setzt deren Kanäle auf "fertig 
+#* konfiguriert".
+#*******************************************************************************
+proc checkDevices { } {
+  rega_script {
+    string sId;
+    foreach(sId, root.Devices().EnumUsedIDs())
+    {
+      var oDevice = dom.GetObject(sId);
+      if (oDevice.ReadyConfig()) { oDevice.ReadyConfigChns(true); }
+    }
+  }
+}
+
+# List of default functions (german "Gewerke") that will be automatically generated
+set FUNCTIONLIST {
+  "funcLight"
+  "funcHeating"
+  "funcClimateControl"
+  "funcWeather"
+  "funcEnvironment"
+  "funcSecurity"
+  "funcLock"
+  "funcButton"
+  "funcCentral"
+  "funcEnergy"
+}
+
+# List of default rooms that will be automatically generated
+set ROOMLIST {
+  "roomLivingRoom"
+  "roomKitchen"
+  "roomBedroom"
+  "roomChildrensRoom1"
+  "roomChildrensRoom2"
+  "roomOffice"
+  "roomBathroom"
+  "roomGarage"
+  "roomHWR"
+  "roomGarden"
+  "roomTerrace"
+}
+
+proc create_objects {collection enum_type names} {
+  set ids [rega "dom.GetObject($collection).EnumIDs()"]
+  set i 0
+
+  foreach name $names {
+    set id [lindex $ids $i]
+    if { "$id" == "" } {
+      #create object first
+      set script "\
+        var new_id = -1;\n\
+        object o = dom.CreateObject( OT_ENUM, \"new object\" );\n\
+        if( o ) \{\n\
+          o.EnumType( $enum_type );\n\
+          boolean res = dom.GetObject( $collection ).Add( o );\n\
+          if( res ) \{\n\
+            new_id = o.ID();\n\
+          \} else \{\n\
+            dom.DeleteObject( o.ID() );\n\
+          \}\n\
+        \}\
+        "
+      #puts "Executing $script"
+      array set r [rega_script $script]
+      set id $r(new_id)
+      if { $id < 0 } {
+        puts "Error creating object"
+      }
+    }
+
+    rega "dom.GetObject($id).Name(\"[lindex $names $i]\")"
+    rega "dom.GetObject($id).Enabled(true)"
+    incr i
+  }
+
+  return [lsort [rega "dom.GetObject($collection).EnumUsedIDs()"]]
+}
+
+proc create_default_functions {} {
+  global FUNCTIONLIST
+  return [create_objects ID_FUNCTIONS etFunction $FUNCTIONLIST]
+}
+
+proc create_default_rooms {} {
+  global ROOMLIST
+  return [create_objects ID_ROOMS etRoom $ROOMLIST]
+}
+
+proc create_default_sysvars {} {
+  rega_script {
+    object sv=dom.CreateObject(OT_ALARMDP, "${sysVarAlarmZone1}");
+    dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
+    sv.DPInfo("${sysVarAlarmZone1Msg}");
+    sv.ValueUnit("");
+    sv.ValueType( ivtBinary );
+    sv.ValueSubType( istAlarm );
+    sv.ValueName1("${sysVarAlarmZone1Triggered}");
+    sv.ValueName0("${sysVarAlarmZone1NotTriggered}");
+    sv.AlType(atSystem);
+    sv.AlArm(true);
+
+    sv=dom.GetObject(ID_PRESENT);
+    dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
+    sv.Name("${sysVarPresence}");
+    sv.DPInfo("${sysVarPresenceMsg}");
+    sv.ValueUnit("");
+    sv.ValueName1("${sysVarPresencePresent}");
+    sv.ValueName0("${sysVarPresenceNotPresent}");
+
+    sv=dom.GetObject(40);
+    dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
+    sv.Name("${sysVarAlarmMessages}");
+    sv.DPInfo("${sysVarAlarmMessagesCount}");
+    sv.Internal(0);
+
+    sv=dom.GetObject(41);
+    dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());
+    sv.Name("${sysVarServiceMessages}");
+    sv.DPInfo("${sysVarServiceMessagesCount}");
+    sv.Internal(0);
+  }
+}
+
+proc create_default_objects {} {
+  array set result [rega_script {
+    string functions=dom.GetObject(ID_FUNCTIONS).EnumUsedIDs();
+    string rooms=dom.GetObject(ID_ROOMS).EnumUsedIDs();
+    string sysvars=dom.GetObject(ID_SYSTEM_VARIABLES).EnumUsedIDs();
+  }]
+
+  set ise_functions [lsort $result(functions)]
+  if { [llength $ise_functions] == 0 } {
+    puts "No functions defined, creating default functions"
+    create_default_functions
+  }
+
+  if { [llength $result(rooms)] == 0 } {
+    puts "No rooms defined, creating default rooms"
+    create_default_rooms
+  }
+
+  if { [llength $result(sysvars)] == 0 } {
+    puts "No system variables defined, creating default system variables"
+    create_default_sysvars
+  }
+}
+
+################################################################################
+# Einsprungpunkt                                                               #
+################################################################################
+
+checkDevices
+create_default_objects
+

--- a/buildroot-external/patches/occu/0072-WebUI-Fix-hm_autoconf/occu/WebUI/bin/hm_startup.orig
+++ b/buildroot-external/patches/occu/0072-WebUI-Fix-hm_autoconf/occu/WebUI/bin/hm_startup.orig
@@ -1,0 +1,44 @@
+#!/bin/tclsh
+
+#*******************************************************************************
+#* hm_startup
+#* Wird beim Starten von ise ReGa ausgeführt. 
+#*
+#* Aufgaben:
+#*   - sucht fertig konfigurierte Geräte und setzt deren Kanäle ebenfalls auf 
+#*     "fertig konfiguriert"
+#*
+#* Autor      : Falk Werner
+#* Erstellt am: 23.07.2008
+#*******************************************************************************
+
+################################################################################
+# Module                                                                       #
+################################################################################
+
+load tclrega.so
+
+################################################################################
+# Prozeduren                                                                   #
+################################################################################
+
+#*******************************************************************************
+#* Sucht fertig konfigurierte Geräte und setzt deren Kanäle auf "fertig 
+#* konfiguriert".
+#*******************************************************************************
+proc checkDevices { } {
+  rega_script {
+    string sId;
+    foreach(sId, root.Devices().EnumUsedIDs())
+    {
+      var oDevice = dom.GetObject(sId);
+      if (oDevice.ReadyConfig()) { oDevice.ReadyConfigChns(true); }
+    }
+  }
+}
+
+################################################################################
+# Einsprungpunkt                                                               #
+################################################################################
+
+checkDevices


### PR DESCRIPTION
Wie schon per Mail andiskutiert die Verlagerung der Erstellung von Systemvariablen, Gewerken und Räumen von hm_autoconf zu hm_startup, damit diese auch erstellt werden, wenn man initial ohne Funkmodul startet.

Zusätzlich ist mir noch ein fetter Bug aufgefallen: Die Gewerke werden beim initialen Start angelegt mit einer definierten Reihenfolge. Bei späteren Aufrufen von hm_autoconf für die automatische Konfiguration von neu angelernten Geräten wurde davon ausgegangen, dass die Gewerke noch exakt so vorhanden sind. Wenn man aber eines gelöscht hat, dann läuft die automatische Zuweisung komplett daneben. Könntest du bitte eQ-3 darauf aufmerksam machen, dass das bitte auch in der CCU gefixt wird?