### PR TITLE
Add workflow to tag

### DIFF
--- a/.github/workflows/set_oci_tag.yml
+++ b/.github/workflows/set_oci_tag.yml
@@ -1,0 +1,37 @@
+name: Set OCI tag
+on:
+  workflow_dispatch:
+    inputs:
+      source_tag:
+        description: 'Source tag'
+        required: true
+        default: "snapshot"
+      target_tag:
+        description: 'Target tag'
+        required: true
+        default: "latest"
+
+jobs:
+  tag:
+    name: Set OCI tag
+    runs-on: ubuntu-20.04
+    steps:
+  
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
+    
+    - name: build and push container image
+      run: |
+        BASE_TAG="ghcr.io/${{ github.repository_owner }}/raspberrymatic"
+        SOURCE_TAG="${BASE_TAG}:${{ github.event.inputs.source_tag }}"
+        TARGET_TAG="${BASE_TAG}:${{ github.event.inputs.target_tag }}"
+        
+        echo "Pulling ${SOURCE_TAG}"
+        docker pull "${SOURCE_TAG}"
+        docker tag "${SOURCE_TAG}" "${TARGET_TAG}"
+        echo "Pushing ${TARGET_TAG}"
+        docker push "${TARGET_TAG}"


### PR DESCRIPTION
<!--

Requirements for Contributing
=============================

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Make sure you have read and understood the CONTRIBUTING.md file in the top-level directory with information related to licensing requirments, etc. In sort: Everything you contribute have to be able to be (re)licensed under the Apache 2.0 license to be able to be contributed to RaspberryMatic

-->

### Description

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
In Docker usually there is a latest that either points to the latest image OR the latest stable. Since we use snapshot already for latest build then I think the "latest" tag should point to the latest stable release.

Since deciding what version goes into the release is a manual decision for now I created a manual workflow to do the tagging directly from the github UI.

@jens-maus - could you please set at least one version as latest so the deploy.sh script works? It points by default to latest so it currently fails until is set.

### Related Issue

<!--- Please link to an open issue here: -->
#786 

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
Do it manually from the command line.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->
Triggered workflow in fork

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in RaspberryMatic's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

### Contributing checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** and **LICENSE** document.
- [x] I fully agree to distribute my changes under Apache 2.0 license.

<!--

Please read and understand the CONTRIBUTING.md file in the top-level directory and also the Apache 2.0 licensing terms. Please make sure to state any licensing conflicts you might have identified / found during development of your pull request. Please also understand that anything you contribute MUST be (re)licenseable under the Apache 2.0 license or otherwise we can not accept your PR for integration.

If you don't have any licensing conflicts please state "Not applicable" or "N/A" which certifies that you have checked the (re)licensing terms and that you are agree with distributing your changes under the Apache 2.0 license

-->
