### PR TITLE
Fix the loading of openvpn configs

### DIFF
--- a/buildroot-external/overlay/base/etc/init.d/S60openvpn
+++ b/buildroot-external/overlay/base/etc/init.d/S60openvpn
@@ -28,7 +28,7 @@ start)
   printf "Starting openvpn:"
 
   if test -z "$2"; then
-    for CONFIG in $(cd "$CONFIG_DIR" || return; ls ./*.conf 2>/dev/null); do
+    for CONFIG in $(cd "$CONFIG_DIR" || return; ls *.conf 2>/dev/null); do
       NAME=${CONFIG%%.conf}
       start_vpn
     done

--- a/buildroot-external/overlay/base/etc/init.d/S60openvpn
+++ b/buildroot-external/overlay/base/etc/init.d/S60openvpn
@@ -28,8 +28,8 @@ start)
   printf "Starting openvpn:"
 
   if test -z "$2"; then
-    for CONFIG in $(cd "$CONFIG_DIR" || return; ls *.conf 2>/dev/null); do
-      NAME=${CONFIG%%.conf}
+    for CONFIG in $(cd "$CONFIG_DIR" || return; ls ./*.conf 2>/dev/null); do
+      NAME=$(basename "${CONFIG%%.conf}")
       start_vpn
     done
   else


### PR DESCRIPTION
### Description

Commit 107f3fb8ed19de2e3a781dac95b0f5c831a53f4e introduced a regression
in the /etc/init.d/S60openvpn script by adding a "./" to the command
listing the config files to load.
However, the command returns that "./" in the results that are iterated
as $NAME variables; the $NAME variable is then used in the generation of
the pid file path as '/var/run/openvpn.$NAME.pid', which becomes invalid.


### Related Issue

/

### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Alternate Designs

/

### Possible Drawbacks

/

### Verification Process

Tested

### Release Notes

- Fix the loading of openvpn configs

### Contributing checklist

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** and **LICENSE** document.
- [x] I fully agree to distribute my changes under Apache 2.0 license.