### PR TITLE
allow the usage of DualCoPro firmware with hmlangw through multimacd

### DIFF
--- a/buildroot-external/overlay/RFD/etc/init.d/S60multimacd
+++ b/buildroot-external/overlay/RFD/etc/init.d/S60multimacd
@@ -11,9 +11,6 @@ STEPS=10
 
 [[ -r /var/hm_mode ]] && . /var/hm_mode
 
-# skip this startup if not in normal mode
-[[ "${HM_MODE}" != "NORMAL" ]] && exit 0
-
 init() {
   # make sure /var/etc/multimacd.conf contains the correct
   # coprocessor device path

--- a/buildroot-external/overlay/base-raspmatic/etc/monitrc
+++ b/buildroot-external/overlay/base-raspmatic/etc/monitrc
@@ -271,7 +271,7 @@ check process multimacd with pidfile /var/run/multimacd.pid
       exec "/bin/triggerAlarm.tcl 'multimacd restarted' 'WatchDog: multimacd-restart' true"
     if filedescriptors > 95% for 5 cycles then
       exec "/bin/triggerAlarm.tcl 'multimacd: high filedescriptor usage (>95%)' 'WatchDog: multimacd-highfd' true"
-    depends on multimacdEnabled, hmlangwDisabled
+    depends on multimacdEnabled
 
 check program multimacdEnabled with path "/usr/bin/test -f /var/etc/multimacd.conf"
     group homematic

--- a/buildroot-external/overlay/base-raspmatic_oci/etc/monitrc
+++ b/buildroot-external/overlay/base-raspmatic_oci/etc/monitrc
@@ -167,7 +167,7 @@ check process multimacd with pidfile /var/run/multimacd.pid
       exec "/bin/triggerAlarm.tcl 'multimacd restarted' 'WatchDog: multimacd-restart' true"
     if filedescriptors > 95% for 5 cycles then
       exec "/bin/triggerAlarm.tcl 'multimacd: high filedescriptor usage (>95%)' 'WatchDog: multimacd-highfd' true"
-    depends on multimacdEnabled, hmlangwDisabled
+    depends on multimacdEnabled
 
 check program multimacdEnabled with path "/usr/bin/test -f /var/etc/multimacd.conf"
     group homematic

--- a/buildroot-external/overlay/base/etc/init.d/S48UpdateRFHardware
+++ b/buildroot-external/overlay/base/etc/init.d/S48UpdateRFHardware
@@ -32,8 +32,6 @@ update_rf_hardware() {
           NEW_VERSION=${FORCED_VERSION}
           FW_FILE="dualcopro_si1002_update_blhm-${FORCED_VERSION}.eq3"
         fi
-      else
-        FW_FILE=coprocessor_update.eq3
       fi
 
       # identify the copro firmware version to be flashed

--- a/buildroot-external/overlay/base/etc/init.d/S48UpdateRFHardware
+++ b/buildroot-external/overlay/base/etc/init.d/S48UpdateRFHardware
@@ -24,14 +24,12 @@ update_rf_hardware() {
       # identify which firmware file to take for a potential coprocessor
       # firmware update
       FORCED_VERSION=
-      if [[ "${HM_MODE}" == "NORMAL" ]]; then
-        if [[ ! -s /etc/config/forced_coprocessor_version ]]; then
-          FW_FILE=dualcopro_si1002_update_blhm.eq3
-        else
-          FORCED_VERSION=$(cat /etc/config/forced_coprocessor_version)
-          NEW_VERSION=${FORCED_VERSION}
-          FW_FILE="dualcopro_si1002_update_blhm-${FORCED_VERSION}.eq3"
-        fi
+      if [[ ! -s /etc/config/forced_coprocessor_version ]]; then
+        FW_FILE=dualcopro_si1002_update_blhm.eq3
+      else
+        FORCED_VERSION=$(cat /etc/config/forced_coprocessor_version)
+        NEW_VERSION=${FORCED_VERSION}
+        FW_FILE="dualcopro_si1002_update_blhm-${FORCED_VERSION}.eq3"
       fi
 
       # identify the copro firmware version to be flashed

--- a/buildroot-external/package/hmlangw/S61hmlangw
+++ b/buildroot-external/package/hmlangw/S61hmlangw
@@ -6,6 +6,7 @@
 
 DAEMON="hmlangw"
 PIDFILE="/var/run/${DAEMON}.pid"
+HM_HMRF_MMDNODE=/dev/mmd_bidcos
 
 [[ -r /var/hm_mode ]] && . /var/hm_mode
 
@@ -15,7 +16,7 @@ PIDFILE="/var/run/${DAEMON}.pid"
 start() {
 	echo -n "Starting LAN Gateway Daemon: "
 	if [[ -c ${HM_HMRF_DEVNODE} ]]; then
-		if start-stop-daemon -S -b -m -p ${PIDFILE} --startas /bin/sh -- -c "exec /bin/${DAEMON} -n ${HM_HMRF_SERIAL} -s ${HM_HMRF_DEVNODE} -r -1 >/var/log/${DAEMON}.log 2>&1"; then
+		if start-stop-daemon -S -b -m -p ${PIDFILE} --startas /bin/sh -- -c "exec /bin/${DAEMON} -n ${HM_HMRF_SERIAL} -s ${HM_HMRF_MMDNODE} -r -1 >/var/log/${DAEMON}.log 2>&1"; then
 			echo "OK"
 		else
 			echo "FAIL"


### PR DESCRIPTION
<!--

Requirements for Contributing
=============================

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Make sure you have read and understood the CONTRIBUTING.md file in the top-level directory with information related to licensing requirments, etc. In sort: Everything you contribute have to be able to be (re)licensed under the Apache 2.0 license to be able to be contributed to RaspberryMatic

-->

### Description

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Allows the usage of radio modules running the "DualCoPro" firmware for the `hmlangw`.
It is no longer necessary to downgrade the HM-MOD-UART (HM-MOD-RPI-PCB) to the old coprocessor firmware version 1.4.1.

Tested with
- HM-MOD-UART 2.8.6
- HmIP-RFUSB 4.4.18
- RPI-RF-MOD 4.4.22

### Related Issue

https://homematic-forum.de/forum/viewtopic.php?f=65&t=77265

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in RaspberryMatic's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

### Contributing checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** and **LICENSE** document.
- [x] I fully agree to distribute my changes under Apache 2.0 license.

<!--

Please read and understand the CONTRIBUTING.md file in the top-level directory and also the Apache 2.0 licensing terms. Please make sure to state any licensing conflicts you might have identified / found during development of your pull request. Please also understand that anything you contribute MUST be (re)licenseable under the Apache 2.0 license or otherwise we can not accept your PR for integration.

If you don't have any licensing conflicts please state "Not applicable" or "N/A" which certifies that you have checked the (re)licensing terms and that you are agree with distributing your changes under the Apache 2.0 license

-->
