### PR TITLE
Correct MetaData MIN+MAX on SV change

### DIFF
--- a/buildroot-external/patches/occu/0097-WebUI-SetSysvarValueByUser.patch
+++ b/buildroot-external/patches/occu/0097-WebUI-SetSysvarValueByUser.patch
@@ -4,8 +4,8 @@
    !sv.ValueSubType(ist);
    sv.DPInfo( system.GetVar("sInfo") );
    sv.ValueUnit( system.GetVar("sUnit") );
-+  sv.ValueMin(null);
-+  sv.ValueMax(null);
++  sv.RemoveMetaData('MIN');
++  sv.RemoveMetaData('MAX');
 +  var svValue;
    if (ist == istAlarm)
    {

--- a/buildroot-external/patches/occu/0097-WebUI-SetSysvarValueByUser.patch
+++ b/buildroot-external/patches/occu/0097-WebUI-SetSysvarValueByUser.patch
@@ -1,14 +1,16 @@
 --- occu/WebUI/www/rega/esp/system.fn.orig
 +++ occu/WebUI/www/rega/esp/system.fn
-@@ -807,6 +807,7 @@
+@@ -807,6 +807,9 @@
    !sv.ValueSubType(ist);
    sv.DPInfo( system.GetVar("sInfo") );
    sv.ValueUnit( system.GetVar("sUnit") );
++  sv.ValueMin(null);
++  sv.ValueMax(null);
 +  var svValue;
    if (ist == istAlarm)
    {
      sv.ValueType( ivtBinary );
-@@ -822,7 +823,7 @@
+@@ -822,7 +825,7 @@
      sv.ValueSubType( istBool );
      sv.ValueName1(system.GetVar("sTrue"));
      sv.ValueName0(system.GetVar("sFalse"));
@@ -17,7 +19,7 @@
    }
    elseif (ist == istGeneric)
    {
-@@ -830,20 +831,20 @@
+@@ -830,20 +833,20 @@
      sv.ValueSubType( istGeneric );
      sv.ValueMin(system.GetVar("iMinVal"));
      sv.ValueMax(system.GetVar("iMaxVal"));
@@ -41,7 +43,7 @@
    }
  
    if (oChn) 
-@@ -860,6 +861,9 @@
+@@ -860,6 +863,9 @@
      }
      sv.Channel( ID_ERROR );
    }

--- a/buildroot-external/patches/occu/0097-WebUI-SetSysvarValueByUser/occu/WebUI/www/rega/esp/system.fn
+++ b/buildroot-external/patches/occu/0097-WebUI-SetSysvarValueByUser/occu/WebUI/www/rega/esp/system.fn
@@ -807,8 +807,8 @@ function ::saveSysVar()
   !sv.ValueSubType(ist);
   sv.DPInfo( system.GetVar("sInfo") );
   sv.ValueUnit( system.GetVar("sUnit") );
-  sv.ValueMin(null);
-  sv.ValueMax(null);
+  sv.RemoveMetaData('MIN');
+  sv.RemoveMetaData('MAX');
   var svValue;
   if (ist == istAlarm)
   {

--- a/buildroot-external/patches/occu/0097-WebUI-SetSysvarValueByUser/occu/WebUI/www/rega/esp/system.fn
+++ b/buildroot-external/patches/occu/0097-WebUI-SetSysvarValueByUser/occu/WebUI/www/rega/esp/system.fn
@@ -807,6 +807,8 @@ function ::saveSysVar()
   !sv.ValueSubType(ist);
   sv.DPInfo( system.GetVar("sInfo") );
   sv.ValueUnit( system.GetVar("sUnit") );
+  sv.ValueMin(null);
+  sv.ValueMax(null);
   var svValue;
   if (ist == istAlarm)
   {


### PR DESCRIPTION
<!--

Requirements for Contributing
=============================

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Make sure you have read and understood the CONTRIBUTING.md file in the top-level directory with information related to licensing requirments, etc. In sort: Everything you contribute have to be able to be (re)licensed under the Apache 2.0 license to be able to be contributed to RaspberryMatic

-->

### Description

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

When changing the type of a system variable, the `MetaData()` of `MIN` and `MAX` are not getting cleared, if the system variable has not a min-to-max range.

This patch will always set the `MetaData(MIN)` and `MetaData(MAX)` to `null` first.


### Related Issue

https://homematic-forum.de/forum/viewtopic.php?f=65&t=77676&start=20#p754163

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in RaspberryMatic's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

### Contributing checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** and **LICENSE** document.
- [x] I fully agree to distribute my changes under Apache 2.0 license.

<!--

Please read and understand the CONTRIBUTING.md file in the top-level directory and also the Apache 2.0 licensing terms. Please make sure to state any licensing conflicts you might have identified / found during development of your pull request. Please also understand that anything you contribute MUST be (re)licenseable under the Apache 2.0 license or otherwise we can not accept your PR for integration.

If you don't have any licensing conflicts please state "Not applicable" or "N/A" which certifies that you have checked the (re)licensing terms and that you are agree with distributing your changes under the Apache 2.0 license

-->
