### PR TITLE
further CloudMatic start/stop/remove/set optimization

### DIFF
--- a/buildroot-external/package/cloudmatic/S97CloudMatic
+++ b/buildroot-external/package/cloudmatic/S97CloudMatic
@@ -30,8 +30,8 @@ start() {
 			rm /etc/config/addons/www/mh
 		fi
 		# remove /usr/local/etc/config/addons/mh if no client.key exists
-		if [[ -d /usr/local/etc/config/addons/mh ]] && [[ ! -f /usr/local/etc/config/addons/mh/client.key ]]; then
-			rm -r /usr/local/etc/config/addons/mh/
+		if [[ -d /etc/config/addons/mh ]] && [[ ! -f /etc/config/addons/mh/client.key ]]; then
+			rm -rf /etc/config/addons/mh
 		fi
 		echo "disabled"
 	else

--- a/buildroot-external/package/cloudmatic/S97CloudMatic
+++ b/buildroot-external/package/cloudmatic/S97CloudMatic
@@ -29,6 +29,10 @@ start() {
 		if [[ -L /etc/config/addons/www/mh ]]; then
 			rm /etc/config/addons/www/mh
 		fi
+		# remove /usr/local/etc/config/addons/mh if no client.key exists
+		if [[ -d /usr/local/etc/config/addons/mh ]] && [[ ! -f /usr/local/etc/config/addons/mh/client.key ]]; then
+			rm -r /usr/local/etc/config/addons/mh/
+		fi
 		echo "disabled"
 	else
 		# CloudMatic (meine-homematic.de) startup

--- a/buildroot-external/patches/occu/0135-WebUI-Add-ControlPanel-AdvancedSettings.patch
+++ b/buildroot-external/patches/occu/0135-WebUI-Add-ControlPanel-AdvancedSettings.patch
@@ -49,7 +49,7 @@
         jQuery.each(helpContainer, function(index, container){
 --- occu/WebUI/www/config/cp_advancedsettings.cgi.orig
 +++ occu/WebUI/www/config/cp_advancedsettings.cgi
-@@ -0,0 +1,627 @@
+@@ -0,0 +1,631 @@
 +#!/bin/tclsh
 +source once.tcl
 +sourceOnce cgi.tcl
@@ -587,10 +587,14 @@
 +    append errMsg [deletefile $MEDIOLAFILENAME]
 +  }
 +  
++  set cloudmaticDisabledCurrent [file exists $CLOUDMATICFILENAME]
 +  if {$cloudmaticDisabled} {
 +    append errMsg [createfile $CLOUDMATICFILENAME]
 +  } else {
 +    append errMsg [deletefile $CLOUDMATICFILENAME]
++  }
++  if {$cloudmaticDisabled != $cloudmaticDisabledCurrent} {
++    exec /etc/init.d/S97CloudMatic restart
 +  }
 +
 +  if {$noCronBackup} {

--- a/buildroot-external/patches/occu/0135-WebUI-Add-ControlPanel-AdvancedSettings/occu/WebUI/www/config/cp_advancedsettings.cgi
+++ b/buildroot-external/patches/occu/0135-WebUI-Add-ControlPanel-AdvancedSettings/occu/WebUI/www/config/cp_advancedsettings.cgi
@@ -535,10 +535,14 @@ proc action_save_settings {} {
     append errMsg [deletefile $MEDIOLAFILENAME]
   }
   
+  set cloudmaticDisabledCurrent [file exists $CLOUDMATICFILENAME]
   if {$cloudmaticDisabled} {
     append errMsg [createfile $CLOUDMATICFILENAME]
   } else {
     append errMsg [deletefile $CLOUDMATICFILENAME]
+  }
+  if {$cloudmaticDisabled != $cloudmaticDisabledCurrent} {
+    exec /etc/init.d/S97CloudMatic restart
   }
 
   if {$noCronBackup} {


### PR DESCRIPTION
<!--

Requirements for Contributing
=============================

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Make sure you have read and understood the CONTRIBUTING.md file in the top-level directory with information related to licensing requirments, etc. In sort: Everything you contribute have to be able to be (re)licensed under the Apache 2.0 license to be able to be contributed to RaspberryMatic

-->

### Description
- removes /usr/local/etc/config/addons/mh/ if no client.key exists (which indicates that cloudmatic isn't used if no client.key exists)

when deactivating Cloudmatic:
- all directories and the button will instant removed when deactivating cloudmatic via advanced settings and closing the settings-window with "ok" (reload of "Systemsteuerung" is required to see the result "Cloudmatic-Button removed")

when activating Cloudmatic:
- all directories and the button will instant set when activating cloudmatic via advanced settings and closing the settings-window with "ok" (reload of "Systemsteuerung" is required to see the result "Cloudmatic-Button set")

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Related Issue

<!--- Please link to an open issue here: -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks
Nothing found 
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Tested these changes on 2 different systems, one with active cloudmatic subscription and the other without subscription.
Works like expected.
<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes
remove cloudmatic completely after deactivating in advance settings (if no user data is stored)
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in RaspberryMatic's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

### Contributing checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** and **LICENSE** document.
- [x] I fully agree to distribute my changes under Apache 2.0 license.

<!--

Please read and understand the CONTRIBUTING.md file in the top-level directory and also the Apache 2.0 licensing terms. Please make sure to state any licensing conflicts you might have identified / found during development of your pull request. Please also understand that anything you contribute MUST be (re)licenseable under the Apache 2.0 license or otherwise we can not accept your PR for integration.

If you don't have any licensing conflicts please state "Not applicable" or "N/A" which certifies that you have checked the (re)licensing terms and that you are agree with distributing your changes under the Apache 2.0 license

-->
