### PR TITLE
HMLANGW: option to prevent entering copro bootloader mode

### DIFF
--- a/buildroot-external/package/hmlangw/S61hmlangw
+++ b/buildroot-external/package/hmlangw/S61hmlangw
@@ -16,7 +16,7 @@ HM_HMRF_MMDNODE=/dev/mmd_bidcos
 start() {
 	echo -n "Starting LAN Gateway Daemon: "
 	if [[ -c ${HM_HMRF_DEVNODE} ]]; then
-		if start-stop-daemon -S -b -m -p ${PIDFILE} --startas /bin/sh -- -c "exec /bin/${DAEMON} -n ${HM_HMRF_SERIAL} -s ${HM_HMRF_MMDNODE} -r -1 >/var/log/${DAEMON}.log 2>&1"; then
+		if start-stop-daemon -S -b -m -p ${PIDFILE} --startas /bin/sh -- -c "exec /bin/${DAEMON} -b -n ${HM_HMRF_SERIAL} -s ${HM_HMRF_MMDNODE} -r -1 >/var/log/${DAEMON}.log 2>&1"; then
 			echo "OK"
 		else
 			echo "FAIL"

--- a/buildroot-external/package/hmlangw/hmframe.cpp
+++ b/buildroot-external/package/hmlangw/hmframe.cpp
@@ -1,6 +1,6 @@
 /* HM-LGW emulation for HM-MOD-RPI
  *
- * Copyright (c) 2015-2023 Oliver Kastl, Jens Maus
+ * Copyright (c) 2015-2023 Oliver Kastl, Jens Maus, Jérôme Pech
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -30,6 +30,7 @@
 #include "hmframe.h"
 
 extern bool g_debug;
+extern bool g_disableEnterBootloader;
 extern void dump_data( const char* data, int length );
 
 int writeall( int fd, const void *buffer, int len )
@@ -65,6 +66,14 @@ static const unsigned char bootloaderReply2[] =
 
 int sendEnterBootloader( int fd )
 {
+    if (g_disableEnterBootloader) 
+    {
+      if( g_debug )
+        fprintf( stderr, "sendEnterBootloader not executed, because disabled (-b option is set).\n");
+        
+      return 0;
+    }
+    
     if( g_debug )
       fprintf( stderr, "sendEnterBootloader(%d)\n", fd);
 

--- a/buildroot-external/package/hmlangw/hmlangw.cpp
+++ b/buildroot-external/package/hmlangw/hmlangw.cpp
@@ -1,6 +1,6 @@
 /* HM-LGW emulation for HM-MOD-RPI
  *
- * Copyright (c) 2015-2023 Oliver Kastl, Jens Maus
+ * Copyright (c) 2015-2023 Oliver Kastl, Jens Maus, Jérôme Pech
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -52,11 +52,12 @@ static int g_serialFd = -1;
 static int g_termEventFd = -1;
 static int g_resetFileFd = -1;
 bool g_debug = false;
+bool g_disableEnterBootloader=false;
 static bool g_inBootloader = false;
 
 //const char *g_productString = "01,eQ3-HM-LGW,1.1.4,ABC0123456";
 
-#define VERSION "1.0.0"
+#define VERSION "1.0.1"
 static char *g_address=NULL;
 static const char *g_productString = "01,Revilo-HM-LGW," VERSION ",%s\r\n";
 
@@ -696,6 +697,7 @@ void hmlangw_syntax(char *prog)
 	fprintf(stderr, "\t-r\tHM-MOD-RPI reset GPIO pin (default 18, -1 to disable)\n");
 	fprintf(stderr, "\t-D\tdebug mode\n");
 	fprintf(stderr, "\t-x\texecute HM-MOD-RPI reset and exit\n");
+	fprintf(stderr, "\t-b\tdo not put CoPro in bootloader mode\n");
 	fprintf(stderr, "\t-h\tthis help\n");
 	fprintf(stderr, "\t-l ip\tlisten on given IP address only (for example 127.0.0.1)\n");
 	fprintf(stderr, "\t-u\tupdate firmware of HM-MOD-RPI\n");
@@ -778,12 +780,15 @@ int main(int argc, char **argv)
     bool forceUpdateFirmware = false;
     bool startThreads = true;
     
-	while((opt = getopt(argc, argv, "DVs:r:l:n:xuf")) != -1)
+	while((opt = getopt(argc, argv, "DbVs:r:l:n:xuf")) != -1)
     {
 		switch (opt)
         {
 			case 'D':
 				g_debug = true;
+				break;
+			case 'b':
+				g_disableEnterBootloader = true;
 				break;
             case 's':
                 serialName = optarg;
@@ -845,7 +850,7 @@ int main(int argc, char **argv)
                 break;
 			case 'V':
 				printf("hmlangw " VERSION "\n");
-				printf("Copyright (c) 2015-2023 Oliver Kastl, Jens Maus\n\n");
+				printf("Copyright (c) 2015-2023 Oliver Kastl, Jens Maus, Jérôme Pech\n\n");
 				exit(EXIT_SUCCESS);
 			case 'h':
 			case ':':


### PR DESCRIPTION
<!--

Requirements for Contributing
=============================

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Make sure you have read and understood the CONTRIBUTING.md file in the top-level directory with information related to licensing requirments, etc. In sort: Everything you contribute have to be able to be (re)licensed under the Apache 2.0 license to be able to be contributed to RaspberryMatic

-->


### Description

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
If we are using an rf-module with DualCoPro firmware (RPI-RF-MOD, HM-MOD-UART FW > 1.4.1), the connection to the co-processor is established via the multimacd, which handles the operating modes (BL or APP).
Therefore the hmlangw is not allowed to put the co-processor in bootloader mode, which can be prevented by the new -b option.

### Related Issue

#2350

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in RaspberryMatic's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

### Contributing checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** and **LICENSE** document.
- [x] I fully agree to distribute my changes under Apache 2.0 license.

<!--

Please read and understand the CONTRIBUTING.md file in the top-level directory and also the Apache 2.0 licensing terms. Please make sure to state any licensing conflicts you might have identified / found during development of your pull request. Please also understand that anything you contribute MUST be (re)licenseable under the Apache 2.0 license or otherwise we can not accept your PR for integration.

If you don't have any licensing conflicts please state "Not applicable" or "N/A" which certifies that you have checked the (re)licensing terms and that you are agree with distributing your changes under the Apache 2.0 license

-->
