### PR TITLE
Update real-time capability check for multimacd

### DIFF
--- a/buildroot-external/overlay/RFD/etc/init.d/S60multimacd
+++ b/buildroot-external/overlay/RFD/etc/init.d/S60multimacd
@@ -107,7 +107,7 @@ start() {
         echo "ERROR: /dev/eq3loop missing"
       fi
     else
-      echo "ERROR: not possible to change real-time scheduling attributes"
+      echo "ERROR: real-time scheduling failed. Real-time group scheduling CONFIG_RT_GROUP_SCHED enabled, but no run time assigned?"
     fi
   else
     echo "not required"

--- a/buildroot-external/overlay/RFD/etc/init.d/S60multimacd
+++ b/buildroot-external/overlay/RFD/etc/init.d/S60multimacd
@@ -82,12 +82,10 @@ start() {
   if [[ -n "${HM_HMIP_DEV}" ]] && [[ -n "${HM_HMRF_DEV}" ]] &&
      ( ( ! echo "${HM_HMIP_DEV}" | grep -q "HMIP-RFUSB" ) || [[ "${HM_HMRF_DEV}" != "HM-CFG-USB-2" ]] ); then
 
-    # we need to check if the system has CONFIG_RT_GROUP_SCHED enabled
-    # and enough cpu.rt_runtime_us shares assigned or otherwise
+    # we need to check if the system allows changing real-time scheduling attributes or otherwise
     # multimacd startup will fail as it uses sched_setscheduler() to
     # raise the real-time priority for processing things with low latency
-    if [[ ! -e /sys/fs/cgroup/cpu/cpu.rt_runtime_us ]] ||
-       [[ $(cat /sys/fs/cgroup/cpu/cpu.rt_runtime_us) -gt 0 ]]; then
+    if chrt -f 10 echo >/dev/null 2>&1; then
 
       # run init function
       init
@@ -109,7 +107,7 @@ start() {
         echo "ERROR: /dev/eq3loop missing"
       fi
     else
-      echo "ERROR: not enough real-time shares (cpu.rt_runtime_us == 0)"
+      echo "ERROR: not possible to change real-time scheduling attributes"
     fi
   else
     echo "not required"

--- a/buildroot-external/overlay/RFD/etc/init.d/S60multimacd
+++ b/buildroot-external/overlay/RFD/etc/init.d/S60multimacd
@@ -85,7 +85,7 @@ start() {
     # we need to check if the system allows changing real-time scheduling attributes or otherwise
     # multimacd startup will fail as it uses sched_setscheduler() to
     # raise the real-time priority for processing things with low latency
-    if chrt -f 10 echo >/dev/null 2>&1; then
+    if /usr/bin/chrt -f 10 echo >/dev/null 2>&1; then
 
       # run init function
       init
@@ -107,7 +107,7 @@ start() {
         echo "ERROR: /dev/eq3loop missing"
       fi
     else
-      echo "ERROR: real-time scheduling failed. Real-time group scheduling CONFIG_RT_GROUP_SCHED enabled, but no run time assigned?"
+      echo "ERROR: real-time scheduling test failed. CONFIG_RT_GROUP_SCHED not set or host kernel unable to utilize sched_setscheduler()"
     fi
   else
     echo "not required"


### PR DESCRIPTION
### Description

Use more generic way to test if we can change real-time scheduling attributes.

On a kernel compiled with `CONFIG_RT_GROUP_SCHED=y` each cgroup domain which wants to use real-time scheduling would need to allocate rt_runtime_us.

If you are stuck with such a kernel one can disable the limit altogether changing the kernel parameter with `sudo sysctl -w kernel.sched_rt_runtime_us=-1` or
`echo "kernel.sched_rt_runtime_us = -1" | sudo tee /etc/sysctl.d/10-disable-rt-group-limit.conf` to make it permanent.

The previous check for real-time capability fails in this case, because it only checks for rt_runtime_us > 0 in the cgroup settings which don't reflect the kernel parameter.

### Related Issue
home-assistant/operating-system#1235
home-assistant/operating-system#2168
#1191

### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Alternate Designs
None considered

### Possible Drawbacks
Not that I'm aware of

### Verification Process
Implemented and tested locally on a Radxa 4SE with Debian Bullseye and Home Assistant supervised install

### Release Notes
N/A

### Contributing checklist
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** and **LICENSE** document.
- [x] I fully agree to distribute my changes under Apache 2.0 license.
