### PR TITLE
fix missing tailscale dns, because of RO filesystem

### DIFF
--- a/buildroot-external/package/tailscale/S46tailscaled
+++ b/buildroot-external/package/tailscale/S46tailscaled
@@ -56,25 +56,27 @@ case "${1}" in
 		#     - dns-os: writing to "/etc/resolv.pre-tailscale-backup.conf" in rename of "/etc/resolv.conf": open /etc/resolv.pre-tailscale-backup.conf: read-only file system
 		#     - dns: writing to "/etc/resolv.pre-tailscale-backup.conf" in rename of "/etc/resolv.conf": open /etc/resolv.pre-tailscale-backup.conf: read-only file system
 
-		# fetch the current tailscale domain
-		domain=$(nslookup $(tailscale ip -1) 100.100.100.100 | grep name | sed -e 's/.*name = [^.]*\.//' -e 's/\.$//')
-		echo "add search domain: $domain"
+		# Append the nameserver directive to resolv.conf
+		echo "nameserver 100.100.100.100" | tee -a /var/etc/resolv.conf > /dev/null
 
 		# Extract the current search domains from resolv.conf
-		current_search=$(grep '^search ' /var/etc/resolv.conf | sed 's/^search //')
+		current_search=$(grep '^search ' /var/etc/resolv.conf | /bin/sed 's/^search //')
+
+		# fetch the current tailscale domain
+		sleep 1
+		domain=$(nslookup $(tailscale ip -1) 100.100.100.100 | /bin/grep name | /bin/sed -e 's/.*name = [^.]*\.//' -e 's/\.$//')
+		echo "add search domain: $domain"
 
 		# Combine the new domain with the existing search domains
 		new_search="$current_search $domain"
 
 		# Update if it already have a search line or add the search line
 		if [[ -n "$current_search" ]]; then
-			sed -i "s/^search .*/search $new_search/" /etc/var/resolv.conf
+			sed -i "s/^search .*/search $new_search/" /var/etc/resolv.conf
 		else
-			echo "search $new_search" | tee -a /etc/var/resolv.conf > /dev/null
+			echo "search $new_search" | tee -a /var/etc/resolv.conf > /dev/null
 		fi
 
-		# Append the nameserver directive to resolv.conf
-		echo "nameserver 100.100.100.100" | tee -a /etc/var/resolv.conf > /dev/null
 	;;
 	stop)
 		echo -n "Stopping ${DAEMON}: "

--- a/buildroot-external/package/tailscale/S46tailscaled
+++ b/buildroot-external/package/tailscale/S46tailscaled
@@ -58,22 +58,23 @@ case "${1}" in
 
 		# fetch the current tailscale domain
 		domain=$(nslookup $(tailscale ip -1) 100.100.100.100 | grep name | sed -e 's/.*name = [^.]*\.//' -e 's/\.$//')
+		echo "add search domain: $domain"
 
 		# Extract the current search domains from resolv.conf
-		current_search=$(grep '^search ' /etc/resolv.conf | sed 's/^search //')
+		current_search=$(grep '^search ' /var/etc/resolv.conf | sed 's/^search //')
 
 		# Combine the new domain with the existing search domains
 		new_search="$current_search $domain"
 
 		# Update if it already have a search line or add the search line
 		if [[ -n "$current_search" ]]; then
-			sudo sed -i "s/^search .*/search $new_search/" /etc/resolv.conf
+			sed -i "s/^search .*/search $new_search/" /etc/var/resolv.conf
 		else
-			echo "search $new_search" | sudo tee -a /etc/resolv.conf > /dev/null
+			echo "search $new_search" | tee -a /etc/var/resolv.conf > /dev/null
 		fi
 
 		# Append the nameserver directive to resolv.conf
-		echo "nameserver 100.100.100.100" | sudo tee -a /etc/resolv.conf > /dev/null
+		echo "nameserver 100.100.100.100" | tee -a /etc/var/resolv.conf > /dev/null
 	;;
 	stop)
 		echo -n "Stopping ${DAEMON}: "
@@ -84,13 +85,13 @@ case "${1}" in
 		# roll the manual added entries back, if tailscale is stopped
 
 		# Remove the "nameserver" line
-		sudo sed -i '/^nameserver/d' /etc/resolv.conf
+		sed -i '/^nameserver 100\.100\.100\.100$/d' /var/etc/resolv.conf
 
 		# Remove search entries containing ".ts.net"
-		sudo sed -i '/\.ts\.net/d' /etc/resolv.conf
+		sed -i '/\.ts\.net/d' /var/etc/resolv.conf
 
 		# Remove the entire search line if it's empty
-		sudo sed -i '/^search $/d' /etc/resolv.conf
+		sed -i '/^search $/d' /var/etc/resolv.conf
 	;;
 	restart|reload)
 		${0} stop

--- a/buildroot-external/package/tailscale/S46tailscaled
+++ b/buildroot-external/package/tailscale/S46tailscaled
@@ -64,7 +64,7 @@ case "${1}" in
 
 		# fetch the current tailscale domain
 		sleep 1
-		domain=$(nslookup "$(tailscale ip -1)" 100.100.100.100 | /bin/grep name | /bin/sed -e 's/.*name = [^.]*\.//' -e 's/\.$//')
+		domain=$(/usr/bin/nslookup "$(/usr/bin/tailscale ip -1)" 100.100.100.100 | /bin/grep name | /bin/sed -e 's/.*name = [^.]*\.//' -e 's/\.$//')
 		echo "add search domain: $domain"
 
 		# Combine the new domain with the existing search domains

--- a/buildroot-external/package/tailscale/S46tailscaled
+++ b/buildroot-external/package/tailscale/S46tailscaled
@@ -51,14 +51,11 @@ case "${1}" in
 		# shellcheck disable=SC2086
 		${TAILSCALE_EXEC} up ${TAILSCALE_UP_ARGS} >/dev/null 2>&1 &
 
-		## adjust the resolv.conf manually because the original way from tailscale return an error see next comment lines
-		# Health check:
-		#     - dns-os: writing to "/etc/resolv.pre-tailscale-backup.conf" in rename of "/etc/resolv.conf": open /etc/resolv.pre-tailscale-backup.conf: read-only file system
-		#     - dns: writing to "/etc/resolv.pre-tailscale-backup.conf" in rename of "/etc/resolv.conf": open /etc/resolv.pre-tailscale-backup.conf: read-only file system
-
-		# Append the nameserver directive to resolv.conf
-		/bin/sed -i '1s/^/nameserver 100.100.100.100\n/' /var/etc/resolv.conf
-		# the search directive is not added, because currently we can not in a defined way fetch it
+		# adjust resolv.conf manually because the original way from tailscale to
+		# add MagicDNS entries returns an error due to read-only /etc directory path.
+		# We also omit an additional search directive because there does not seem to
+		# be a well defined way to obtain these search names from tailscale
+		sed -i '1s/^/nameserver 100.100.100.100\n/' /etc/resolv.conf
 	;;
 	stop)
 		echo -n "Stopping ${DAEMON}: "
@@ -66,10 +63,8 @@ case "${1}" in
 		start-stop-daemon -K -q -p ${TAILSCALED_PID}
 		echo "OK"
 
-		# roll the manual added entries back, if tailscale is stopped
-
-		# Remove the "nameserver" line
-		/bin/sed -i '/^nameserver 100\.100\.100\.100$/d' /var/etc/resolv.conf
+		# roll the manual added /etc/resolv.conf entries back, if tailscale is stopped
+		sed -i '/^nameserver 100\.100\.100\.100$/d' /etc/resolv.conf
 	;;
 	restart|reload)
 		${0} stop

--- a/buildroot-external/package/tailscale/S46tailscaled
+++ b/buildroot-external/package/tailscale/S46tailscaled
@@ -59,7 +59,7 @@ case "${1}" in
 		# Append the nameserver directive to resolv.conf
 		/bin/sed -i '1s/^/nameserver 100.100.100.100\n/' /var/etc/resolv.conf
 		# the search directive is not added, because currently we can not in a defined way fetch it
-
+	;;
 	stop)
 		echo -n "Stopping ${DAEMON}: "
 		start-stop-daemon -K -q -p ${TAILSCALE_PID}

--- a/buildroot-external/package/tailscale/S46tailscaled
+++ b/buildroot-external/package/tailscale/S46tailscaled
@@ -30,7 +30,7 @@ case "${1}" in
 
 		# make sure we have a valid PATH variable
 		export PATH=/sbin:/usr/bin:/usr/sbin
-	
+
 		# make sure ip forwarding is turned on for v4/v6
 		/sbin/sysctl -q net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1 2>/dev/null
 
@@ -50,7 +50,6 @@ case "${1}" in
 		# make sure to set tailscale 'up' with the right cmdline args
 		# shellcheck disable=SC2086
 		${TAILSCALE_EXEC} up ${TAILSCALE_UP_ARGS} >/dev/null 2>&1 &
-
 
 		## adjust the resolv.conf manually because the original way from tailscale return an error see next comment lines
 		# Health check:

--- a/buildroot-external/package/tailscale/S46tailscaled
+++ b/buildroot-external/package/tailscale/S46tailscaled
@@ -57,27 +57,9 @@ case "${1}" in
 		#     - dns: writing to "/etc/resolv.pre-tailscale-backup.conf" in rename of "/etc/resolv.conf": open /etc/resolv.pre-tailscale-backup.conf: read-only file system
 
 		# Append the nameserver directive to resolv.conf
-		echo "nameserver 100.100.100.100" | tee -a /var/etc/resolv.conf > /dev/null
+		/bin/sed -i '1s/^/nameserver 100.100.100.100\n/' /var/etc/resolv.conf
+		# the search directive is not added, because currently we can not in a defined way fetch it
 
-		# Extract the current search domains from resolv.conf
-		current_search=$(grep '^search ' /var/etc/resolv.conf | /bin/sed 's/^search //')
-
-		# fetch the current tailscale domain
-		sleep 1
-		domain=$(/usr/bin/nslookup "$(/usr/bin/tailscale ip -1)" 100.100.100.100 | /bin/grep name | /bin/sed -e 's/.*name = [^.]*\.//' -e 's/\.$//')
-		echo "add search domain: $domain"
-
-		# Combine the new domain with the existing search domains
-		new_search="$current_search $domain"
-
-		# Update if it already have a search line or add the search line
-		if [[ -n "$current_search" ]]; then
-			sed -i "s/^search .*/search $new_search/" /var/etc/resolv.conf
-		else
-			echo "search $new_search" | tee -a /var/etc/resolv.conf > /dev/null
-		fi
-
-	;;
 	stop)
 		echo -n "Stopping ${DAEMON}: "
 		start-stop-daemon -K -q -p ${TAILSCALE_PID}
@@ -87,13 +69,7 @@ case "${1}" in
 		# roll the manual added entries back, if tailscale is stopped
 
 		# Remove the "nameserver" line
-		sed -i '/^nameserver 100\.100\.100\.100$/d' /var/etc/resolv.conf
-
-		# Remove search entries containing ".ts.net"
-		sed -i '/\.ts\.net/d' /var/etc/resolv.conf
-
-		# Remove the entire search line if it's empty
-		sed -i '/^search $/d' /var/etc/resolv.conf
+		/bin/sed -i '/^nameserver 100\.100\.100\.100$/d' /var/etc/resolv.conf
 	;;
 	restart|reload)
 		${0} stop

--- a/buildroot-external/package/tailscale/S46tailscaled
+++ b/buildroot-external/package/tailscale/S46tailscaled
@@ -64,7 +64,7 @@ case "${1}" in
 
 		# fetch the current tailscale domain
 		sleep 1
-		domain=$(nslookup $(tailscale ip -1) 100.100.100.100 | /bin/grep name | /bin/sed -e 's/.*name = [^.]*\.//' -e 's/\.$//')
+		domain=$(nslookup "$(tailscale ip -1)" 100.100.100.100 | /bin/grep name | /bin/sed -e 's/.*name = [^.]*\.//' -e 's/\.$//')
 		echo "add search domain: $domain"
 
 		# Combine the new domain with the existing search domains

--- a/buildroot-external/package/tailscale/S46tailscaled
+++ b/buildroot-external/package/tailscale/S46tailscaled
@@ -30,7 +30,7 @@ case "${1}" in
 
 		# make sure we have a valid PATH variable
 		export PATH=/sbin:/usr/bin:/usr/sbin
-
+	
 		# make sure ip forwarding is turned on for v4/v6
 		/sbin/sysctl -q net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1 2>/dev/null
 
@@ -50,12 +50,48 @@ case "${1}" in
 		# make sure to set tailscale 'up' with the right cmdline args
 		# shellcheck disable=SC2086
 		${TAILSCALE_EXEC} up ${TAILSCALE_UP_ARGS} >/dev/null 2>&1 &
+
+
+		## adjust the resolv.conf manually because the original way from tailscale return an error see next comment lines
+		# Health check:
+		#     - dns-os: writing to "/etc/resolv.pre-tailscale-backup.conf" in rename of "/etc/resolv.conf": open /etc/resolv.pre-tailscale-backup.conf: read-only file system
+		#     - dns: writing to "/etc/resolv.pre-tailscale-backup.conf" in rename of "/etc/resolv.conf": open /etc/resolv.pre-tailscale-backup.conf: read-only file system
+
+		# fetch the current tailscale domain
+		domain=$(nslookup $(tailscale ip -1) 100.100.100.100 | grep name | sed -e 's/.*name = [^.]*\.//' -e 's/\.$//')
+
+		# Extract the current search domains from resolv.conf
+		current_search=$(grep '^search ' /etc/resolv.conf | sed 's/^search //')
+
+		# Combine the new domain with the existing search domains
+		new_search="$current_search $domain"
+
+		# Update if it already have a search line or add the search line
+		if [[ -n "$current_search" ]]; then
+			sudo sed -i "s/^search .*/search $new_search/" /etc/resolv.conf
+		else
+			echo "search $new_search" | sudo tee -a /etc/resolv.conf > /dev/null
+		fi
+
+		# Append the nameserver directive to resolv.conf
+		echo "nameserver 100.100.100.100" | sudo tee -a /etc/resolv.conf > /dev/null
 	;;
 	stop)
 		echo -n "Stopping ${DAEMON}: "
 		start-stop-daemon -K -q -p ${TAILSCALE_PID}
 		start-stop-daemon -K -q -p ${TAILSCALED_PID}
 		echo "OK"
+
+		# roll the manual added entries back, if tailscale is stopped
+
+		# Remove the "nameserver" line
+		sudo sed -i '/^nameserver/d' /etc/resolv.conf
+
+		# Remove search entries containing ".ts.net"
+		sudo sed -i '/\.ts\.net/d' /etc/resolv.conf
+
+		# Remove the entire search line if it's empty
+		sudo sed -i '/^search $/d' /etc/resolv.conf
 	;;
 	restart|reload)
 		${0} stop


### PR DESCRIPTION
### Description

Because of the RO filesystem the normal mechanism for tailscale magicDNS does not work.

You can see it for example if you run the command
`tailscale status`

it shows some lines and than the error:

```bash
#     - dns-os: writing to "/etc/resolv.pre-tailscale-backup.conf" in rename of "/etc/resolv.conf": open /etc/resolv.pre-tailscale-backup.conf: read-only file system
#     - dns: writing to "/etc/resolv.pre-tailscale-backup.conf" in rename of "/etc/resolv.conf": open /etc/resolv.pre-tailscale-backup.conf: read-only file system

```


### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Release Notes

add tailscale magicDNS support with the readonly filesystem

### Contributing checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** and **LICENSE** document.
- [X] I fully agree to distribute my changes under Apache 2.0 license.

