### PR TITLE
enhanced all SXX init scripts which can execute an rc.xxx file

### DIFF
--- a/buildroot-external/overlay/base/etc/init.d/S06InitSystem
+++ b/buildroot-external/overlay/base/etc/init.d/S06InitSystem
@@ -117,7 +117,7 @@ start() {
   if [[ ! -e /etc/config/safemode ]]; then
     if [[ -x /usr/local/etc/rc.init ]]; then
       echo -n "rc.init, "
-      timeout 120 /usr/local/etc/rc.init
+      /usr/bin/timeout 120 /usr/local/etc/rc.init
     fi
   fi
 
@@ -133,7 +133,7 @@ start() {
   if [[ ! -e /etc/config/safemode ]]; then
     if [[ -x /usr/local/etc/rc.postinit ]]; then
       echo -n "rc.postinit, "
-      timeout 120 /usr/local/etc/rc.postinit
+      /usr/bin/timeout 120 /usr/local/etc/rc.postinit
     fi
   fi
 

--- a/buildroot-external/overlay/base/etc/init.d/S06InitSystem
+++ b/buildroot-external/overlay/base/etc/init.d/S06InitSystem
@@ -116,7 +116,8 @@ start() {
   # call rc.init before initializing the system
   if [[ ! -e /etc/config/safemode ]]; then
     if [[ -x /usr/local/etc/rc.init ]]; then
-      /usr/local/etc/rc.init
+      echo -n "rc.init, "
+      timeout 120 /usr/local/etc/rc.init
     fi
   fi
 
@@ -131,7 +132,8 @@ start() {
   # call rc.postinit after init of system is finished
   if [[ ! -e /etc/config/safemode ]]; then
     if [[ -x /usr/local/etc/rc.postinit ]]; then
-      /usr/local/etc/rc.postinit
+      echo -n "rc.postinit, "
+      timeout 120 /usr/local/etc/rc.postinit
     fi
   fi
 

--- a/buildroot-external/overlay/base/etc/init.d/S55InitAddons
+++ b/buildroot-external/overlay/base/etc/init.d/S55InitAddons
@@ -22,7 +22,7 @@ start() {
     # executable
     if [[ -x /usr/local/etc/rc.prelocal ]]; then
       echo -n "rc.prelocal, "
-      timeout 120 /usr/local/etc/rc.prelocal
+      /usr/bin/timeout 120 /usr/local/etc/rc.prelocal
     fi
 
     # start init of third-party addons one after another

--- a/buildroot-external/overlay/base/etc/init.d/S55InitAddons
+++ b/buildroot-external/overlay/base/etc/init.d/S55InitAddons
@@ -21,7 +21,8 @@ start() {
     # call /usr/local/etc/rc.prelocal if it exists and is
     # executable
     if [[ -x /usr/local/etc/rc.prelocal ]]; then
-      /usr/local/etc/rc.prelocal
+      echo -n "rc.prelocal, "
+      timeout 120 /usr/local/etc/rc.prelocal
     fi
 
     # start init of third-party addons one after another

--- a/buildroot-external/overlay/base/etc/init.d/S98StartAddons
+++ b/buildroot-external/overlay/base/etc/init.d/S98StartAddons
@@ -42,7 +42,7 @@ start() {
     # call rc.local
     if [[ -x /usr/local/etc/rc.local ]]; then
       echo -n "rc.local, "
-      timeout 120 /usr/local/etc/rc.local
+      /usr/bin/timeout 120 /usr/local/etc/rc.local
     fi
 
     echo "OK"

--- a/buildroot-external/overlay/base/etc/init.d/S98StartAddons
+++ b/buildroot-external/overlay/base/etc/init.d/S98StartAddons
@@ -41,7 +41,8 @@ start() {
 
     # call rc.local
     if [[ -x /usr/local/etc/rc.local ]]; then
-      /usr/local/etc/rc.local
+      echo -n "rc.local, "
+      timeout 120 /usr/local/etc/rc.local
     fi
 
     echo "OK"

--- a/buildroot-external/overlay/base/etc/init.d/S99SetupLEDs
+++ b/buildroot-external/overlay/base/etc/init.d/S99SetupLEDs
@@ -48,7 +48,8 @@ start() {
 
   # execute /usr/local/etc/rc.postlocal (but not in safemode)
   if [[ -x /usr/local/etc/rc.postlocal ]] && [[ ! -e /etc/config/safemode ]]; then
-    /usr/local/etc/rc.postlocal
+    echo -n "rc.postlocal, "
+    timeout 120 /usr/local/etc/rc.postlocal
   fi
   
   # if we are in safemode we remove the safemode control-file

--- a/buildroot-external/overlay/base/etc/init.d/S99SetupLEDs
+++ b/buildroot-external/overlay/base/etc/init.d/S99SetupLEDs
@@ -49,7 +49,7 @@ start() {
   # execute /usr/local/etc/rc.postlocal (but not in safemode)
   if [[ -x /usr/local/etc/rc.postlocal ]] && [[ ! -e /etc/config/safemode ]]; then
     echo -n "rc.postlocal, "
-    timeout 120 /usr/local/etc/rc.postlocal
+    /usr/bin/timeout 120 /usr/local/etc/rc.postlocal
   fi
   
   # if we are in safemode we remove the safemode control-file


### PR DESCRIPTION

<!--

Requirements for Contributing
=============================

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Make sure you have read and understood the CONTRIBUTING.md file in the top-level directory with information related to licensing requirments, etc. In sort: Everything you contribute have to be able to be (re)licensed under the Apache 2.0 license to be able to be contributed to RaspberryMatic

-->

### Description
- added timeout 120 to execute command, eg: `timeout 120 /usr/local/etc/rc.local`
- added echo output if `rc.xxx` file exists and is executable, eg: `echo -n "rc.local, "` 
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Related Issue
https://github.com/jens-maus/RaspberryMatic/issues/2448#issuecomment-1737142215
<!--- Please link to an open issue here: -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks
If the user uses all 5 rc.xxx with functions that never ends, bootime will be increase for at least 10 Minutes.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Implemented this change on my RaspberryMatic Testsystem and booted multiple times.
Output looks fine (all 5 rc.xxx are available), but i don't tested the timeouts yet.

```
fsck 1.47.0 (5-Feb-2023)
userfs: clean, 547/704512 files, 204089/2817792 blocks
Starting watchdog...
Identifying host system: ova-KVM, OK
Initializing ZRAM Swap: OK
Initializing RTC Clock: onboard, OK
Starting acpid: OK
Running sysctl: OK
Running seedrng: OK
Checking for Factory Reset: not required
Checking for Backup Restore: not required
Initializing System: rc.init, rc.postinit, OK
Setup ca-certificates: OK
Starting logging: OK
Populating /dev using udev: done
Init onboard LEDs: init, OK
Starting qemu-guest-agent: OK
Starting irqbalance: OK
Starting system message bus: done
Starting iptables: OK
Starting bluetoothd: disabled
Starting network: eth0: link up, dhcp, firewall, inet up, 192.168.113.96, wlan0: missing, OK
Starting Network Interface Plugging Daemon: eth0.
Starting chrony: OK
Identifying Homematic RF-Hardware: ....HmRF: HMIP-RFUSB/eQ-3 HmIP-RFUSB@usb-0000:02:1b.0-1, HmIP: HMIP-RFUSB/eQ-3 HmIP-RFUSB@usb-0000:02:1b.0-1, OK
Updating Homematic RF-Hardware: HMIP-RFUSB: 4.4.18, not necessary, OK
Starting hs485dLoader: disabled
Starting xinetd: OK
Starting eq3configd: OK
Starting lighttpd: OK
Starting ser2net: disabled
Starting ssdpd: OK
Starting sshd: OK
Starting NUT services: disabled
Initializing Third-Party Addons: rc.prelocal, OK
Starting LGWFirmwareUpdate: ...OK
Setting LAN Gateway keys: OK
Starting SNMP daemon: OK
Starting hs485d: disabled
Starting multimacd: ...OK
Starting rfd: .OK
Starting HMIPServer: .........OK
Starting ReGaHss: .OK
Starting CloudMatic: disabled
Starting Third-Party Addons: rc.local, OK
Starting crond: OK
Setup onboard LEDs: rc.postlocal, booted, OK
Finished Boot: 3.71.12.20230927 (raspmatic_ova)
```


<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes
Added timeout and echo output to all SXX init scripts which can execute rc.xxx files.
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in RaspberryMatic's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

### Contributing checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** and **LICENSE** document.
- [x] I fully agree to distribute my changes under Apache 2.0 license.

<!--

Please read and understand the CONTRIBUTING.md file in the top-level directory and also the Apache 2.0 licensing terms. Please make sure to state any licensing conflicts you might have identified / found during development of your pull request. Please also understand that anything you contribute MUST be (re)licenseable under the Apache 2.0 license or otherwise we can not accept your PR for integration.

If you don't have any licensing conflicts please state "Not applicable" or "N/A" which certifies that you have checked the (re)licensing terms and that you are agree with distributing your changes under the Apache 2.0 license

-->
