### PR TITLE
optimized / reworked 0130-WebUI-Fix-ChannelSysVarPrefix.patch

### DIFF
--- a/buildroot-external/patches/occu/0130-WebUI-Fix-ChannelSysVarPrefix.patch
+++ b/buildroot-external/patches/occu/0130-WebUI-Fix-ChannelSysVarPrefix.patch
@@ -5,12 +5,12 @@
  function ::getSpecialTranslationPrgDest() {
    ! ASIR - Adds the string "Alarmsignal: " to the original value.
 -  if (oDP.HSSID() == "ACOUSTIC_ALARM_SELECTION") {
-+  if (oCH.HssType() == "ACOUSTIC_ALARM_SELECTION") {
++  if ((oCH.HssParentType().ToUpper().Contains("ASIR")) && (oDP.HSSID() == "ACOUSTIC_ALARM_SELECTION")) {
      sValue = "${acousticAlarm}: "#sValue;
    }
    ! ASIR - Adds the string "Alarmsignal: " to the original value.
 -  if (oDP.HSSID() == "OPTICAL_ALARM_SELECTION") {
-+  if (oCH.HssType() == "OPTICAL_ALARM_SELECTION") {
++  if ((oCH.HssParentType().ToUpper().Contains("ASIR")) && (oDP.HSSID() == "OPTICAL_ALARM_SELECTION")) {
      sValue = "${opticalAlarm}: "#sValue;
    }
  

--- a/buildroot-external/patches/occu/0130-WebUI-Fix-ChannelSysVarPrefix/occu/WebUI/www/rega/esp/functions.fn
+++ b/buildroot-external/patches/occu/0130-WebUI-Fix-ChannelSysVarPrefix/occu/WebUI/www/rega/esp/functions.fn
@@ -871,11 +871,11 @@ function ::getSpecialTranslationPrgCond() {
 
 function ::getSpecialTranslationPrgDest() {
   ! ASIR - Adds the string "Alarmsignal: " to the original value.
-  if (oCH.HssType() == "ACOUSTIC_ALARM_SELECTION") {
+  if ((oCH.HssParentType().ToUpper().Contains("ASIR")) && (oDP.HSSID() == "ACOUSTIC_ALARM_SELECTION")) {
     sValue = "${acousticAlarm}: "#sValue;
   }
   ! ASIR - Adds the string "Alarmsignal: " to the original value.
-  if (oCH.HssType() == "OPTICAL_ALARM_SELECTION") {
+  if ((oCH.HssParentType().ToUpper().Contains("ASIR")) && (oDP.HSSID() == "OPTICAL_ALARM_SELECTION")) {
     sValue = "${opticalAlarm}: "#sValue;
   }
 


### PR DESCRIPTION
<!--

Requirements for Contributing
=============================

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Make sure you have read and understood the CONTRIBUTING.md file in the top-level directory with information related to licensing requirments, etc. In sort: Everything you contribute have to be able to be (re)licensed under the Apache 2.0 license to be able to be contributed to RaspberryMatic

-->

### Description
- returns the prefixes 'optical signal' / acoustical signal' to then-actions for HmIP-ASIR in webui-programs
- retains the original function of the patch, don't show the prefixes for channel assigned system variables

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Related Issue

<!--- Please link to an open issue here: -->
none
### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Alternate Designs
none
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks
not known
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Implemented this optimized patch on my testsystem with HmIP-ASIR. 
Checked "then-actions" on ASIR alarm-channel and on devices with channel assigned system variables.
No problems found so far.
<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes
Returns the prefixes 'optical signal' / acoustical signal' to then-actions for HmIP-ASIR alarm-channel in webui-programs.
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in RaspberryMatic's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

### Contributing checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** and **LICENSE** document.
- [x] I fully agree to distribute my changes under Apache 2.0 license.

<!--

Please read and understand the CONTRIBUTING.md file in the top-level directory and also the Apache 2.0 licensing terms. Please make sure to state any licensing conflicts you might have identified / found during development of your pull request. Please also understand that anything you contribute MUST be (re)licenseable under the Apache 2.0 license or otherwise we can not accept your PR for integration.

If you don't have any licensing conflicts please state "Not applicable" or "N/A" which certifies that you have checked the (re)licensing terms and that you are agree with distributing your changes under the Apache 2.0 license

-->
