### PR TITLE
modified patch-ha-addon-macvlan.sh script to print default addon name  in interactive mode

### DIFF
--- a/scripts/patch-ha-addon-macvlan.sh
+++ b/scripts/patch-ha-addon-macvlan.sh
@@ -126,7 +126,7 @@ fi
 
 echo -n "RaspberryMatic Add-on Hostname (e.g. 5422eb72-raspberrymatic): "
 if [[ -z "${CCU_CONTAINER_NAME}" ]]; then
-  CCU_CONTAINER_NAME=$(docker ps --format '{{.Names}}' | grep "_raspberrymatic" | cut -c7-)
+  CCU_CONTAINER_NAME=$(docker ps --format '{{.Names}}' | grep "_raspberrymatic" | cut -c7- | awk '{print $0}')
   if [[ -z "${NON_INTERACTIVE}" ]]; then
     read -r -e -i "${CCU_CONTAINER_NAME}" CCU_CONTAINER_NAME </dev/tty
   else


### PR DESCRIPTION
### Description

I modified the patch-ha-addon-macvlan.sh script, so that in interactive usage the name of the addon container is printed into the console. To accept the default value the user just have to press enter. 

### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Release Notes

N/A

### Contributing checklist
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** and **LICENSE** document.
- [x] I fully agree to distribute my changes under Apache 2.0 license.
