### PR TITLE
fix picod compilation breakage with GCC14

### DIFF
--- a/buildroot-external/package/picod/0001-fix-gcc14.patch
+++ b/buildroot-external/package/picod/0001-fix-gcc14.patch
@@ -4,7 +4,7 @@ Upstream: Not applicable
 
 Signed-off-by: Jens Maus <mail@jens-maus.de>
 
---- a/pico-i2cd.c.orig	2025-09-20 23:31:52.760180510 +0200
+--- a/pico-i2cd.c	2025-09-20 23:31:52.760180510 +0200
 +++ b/pico-i2cd.c	2025-09-20 23:30:04.804670057 +0200
 @@ -48,6 +48,8 @@
  /* for Linux input device macros */

--- a/buildroot-external/package/picod/picod.mk
+++ b/buildroot-external/package/picod/picod.mk
@@ -9,8 +9,10 @@ PICOD_SITE = $(call github,ef-gy,rpi-ups-pico,$(PICOD_VERSION))
 PICOD_LICENSE = MIT
 PICOD_LICENSE_FILES = LICENSE
 
+PICOD_DEPENDENCIES += i2c-tools
+
 define PICOD_BUILD_CMDS
-	$(MAKE) $(TARGET_CONFIGURE_OPTS) CFLAGS+="-I../i2c-tools-4.0/include/" LDFLAGS+="-L../i2c-tools-4.0/lib -li2c" -C $(@D) all
+	$(MAKE) $(TARGET_CONFIGURE_OPTS) LDFLAGS+="-li2c" -C $(@D) all
 endef
 
 define PICOD_INSTALL_TARGET_CMDS


### PR DESCRIPTION
This change adds i2c/smbus.h include to fix implicit declaration compile errors with GCC14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build failures with newer GCC (GCC 14) to restore successful compilation; no runtime or public API changes.

* **Chores**
  * Added an i2c tooling dependency and simplified build linking so the compatibility fix is applied automatically during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->