### PR TITLE
fix missing vsprintf.h include for simple_strtoul() declaration.

### DIFF
--- a/buildroot-external/patches/uboot/2023.01/0001-CMD-read-string-from-fileinto-env.patch
+++ b/buildroot-external/patches/uboot/2023.01/0001-CMD-read-string-from-fileinto-env.patch
@@ -24,10 +24,11 @@
  obj-$(CONFIG_CMD_STRINGS) += strings.o
 --- a/cmd/fileenv.c	1970-01-01 01:00:00.000000000 +0100
 +++ b/cmd/fileenv.c	2025-01-30 23:56:16.396279241 +0100
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,47 @@
 +#include <config.h>
 +#include <common.h>
 +#include <command.h>
++#include <vsprintf.h>
 +#include <fs.h>
 +#include <linux/ctype.h>
 +

--- a/buildroot-external/patches/uboot/2025.04/0001-CMD-read-string-from-fileinto-env.patch
+++ b/buildroot-external/patches/uboot/2025.04/0001-CMD-read-string-from-fileinto-env.patch
@@ -44,9 +44,10 @@ new file mode 100644
 index 00000000000..4154c8df0f0
 --- /dev/null
 +++ b/cmd/fileenv.c
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,46 @@
 +#include <config.h>
 +#include <command.h>
++#include <vsprintf.h>
 +#include <fs.h>
 +#include <linux/ctype.h>
 +


### PR DESCRIPTION
This change fixes the tinkerboard and odroid platform related builds where due to a missing vsprintf.h include statement in the fileenv.c patchset for U-boot 2023.01 and 2025.04 GCC14+ complained about an implicit declaration and exited with an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new U-Boot CLI command “fileenv” to read a file from a FAT filesystem and store its contents into an environment variable.
  * Automatically sanitizes non-printable characters and ensures proper null-termination for safe use as a string.
  * Provides simple usage: specify interface, device/partition, load address, filename, and target environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->