### PR TITLE
use DEPLOY_KEY to allow to bypass master branch commit rules.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -533,6 +533,8 @@ jobs:
         with:
           persist-credentials: false
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+          fetch-depth: 0
+          ref: master
 
       - name: Bump HomeAssistant add-on version
         run: |
@@ -559,7 +561,6 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: OpenCCU-${{ needs.release_draft.outputs.version }}-rpi5.mf
-
 
       - name: Bump rpi-imager version
         run: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -521,6 +521,8 @@ jobs:
         with:
           persist-credentials: false
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+          fetch-depth: 0
+          ref: master
 
       - name: Setup Environment
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release and snapshot publishing workflows to use SSH-based checkout with non-persisting credentials and full repository fetch.
  * No changes to product features or user-facing behavior; release process remains transparent to end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->