### PR TITLE
Revert "Bump snok/container-retention-policy from 3.0.0 to 3.0.1"

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -589,7 +589,7 @@ jobs:
         continue-on-error: true
 
       - name: Remove old unused container images
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.0.0
         with:
           account: user
           token: ${{ secrets.CR_PAT }}


### PR DESCRIPTION
This PR reverts commit 062b09848b84fa65ce61fd0cd45840a8f6756527 which again downgrades snok/container-retention-policy  to the working v3.0.0 version. At the same time we disabled the auto-merge workflow for the time being so that we can tell dependabot to ignore that version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration for container image cleanup by adjusting the retention policy action version.
  * Ensures ongoing maintenance of build artifacts without altering application behavior.
  * No impact on features, performance, or user workflows.
  * Deployment and build pipelines remain stable; change is limited to internal automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->