### PR TITLE
fix potential curl redirect issue in downloadFirmware.tcl.

### DIFF
--- a/buildroot-external/patches/occu/0001-OpenCCU.patch
+++ b/buildroot-external/patches/occu/0001-OpenCCU.patch
@@ -16,7 +16,7 @@
 -  set result [catch {exec echo "nomatch" >> /tmp/test} msg]
 -  jsonrpc_response false
 -}
-+set result [catch {exec curl -s https://openccu.de/LATEST-VERSION.js} verstring]
++set result [catch {exec curl -s -L https://openccu.de/LATEST-VERSION.js} verstring]
 +set result [regexp {homematic\.com\.setLatestVersion\('(.+)', 'HM-RASPBERRYMATIC'\);} $verstring match latest ]
 +set result [catch {exec grep PLATFORM /VERSION | cut -d= -f2} platform]
 +set url "https://github.com/openccu/openccu/releases/download/$latest/OpenCCU-$latest-$platform.zip"

--- a/buildroot-external/patches/occu/0001-OpenCCU/occu/WebUI/www/api/methods/ccu/downloadFirmware.tcl
+++ b/buildroot-external/patches/occu/0001-OpenCCU/occu/WebUI/www/api/methods/ccu/downloadFirmware.tcl
@@ -8,7 +8,7 @@
 # Rueckgabewert: True wenn eine Firmware erfolgreich herunterladen wurde, ansonsten False.
 ##
 
-set result [catch {exec curl -s https://openccu.de/LATEST-VERSION.js} verstring]
+set result [catch {exec curl -s -L https://openccu.de/LATEST-VERSION.js} verstring]
 set result [regexp {homematic\.com\.setLatestVersion\('(.+)', 'HM-RASPBERRYMATIC'\);} $verstring match latest ]
 set result [catch {exec grep PLATFORM /VERSION | cut -d= -f2} platform]
 set url "https://github.com/openccu/openccu/releases/download/$latest/OpenCCU-$latest-$platform.zip"

--- a/buildroot-external/patches/occu/0199-WebUI-ImprovedSystemProtocol.patch
+++ b/buildroot-external/patches/occu/0199-WebUI-ImprovedSystemProtocol.patch
@@ -54,7 +54,7 @@
    var s = "";
 --- occu/WebUI/www/webui/webui.js.orig
 +++ occu/WebUI/www/webui/webui.js
-@@ -40670,10 +40670,10 @@
+@@ -40673,10 +40673,10 @@
        }
        else
        {

--- a/buildroot-external/patches/occu/0199-WebUI-ImprovedSystemProtocol/occu/WebUI/www/rega/pages/tabs/control/systemProtocol.htm
+++ b/buildroot-external/patches/occu/0199-WebUI-ImprovedSystemProtocol/occu/WebUI/www/rega/pages/tabs/control/systemProtocol.htm
@@ -43,10 +43,10 @@ ResetGAC();
 
 <table class="tTable filterTable" id="SysProtoList" cellspacing="0" cellpadding="0" style="display:none">
   <colgroup>
-    <col style="width:12%;"/>
-    <col style="width:12%;"/>
-    <col style="width:16%;"/>
-    <col style="width:60%;"/>
+    <col />
+    <col />
+    <col />
+    <col />
   </colgroup>
   <thead id="histlistheader">
       <tr>

--- a/buildroot-external/patches/occu/0199-WebUI-ImprovedSystemProtocol/occu/WebUI/www/rega/pages/tabs/control/systemProtocol.htm.orig
+++ b/buildroot-external/patches/occu/0199-WebUI-ImprovedSystemProtocol/occu/WebUI/www/rega/pages/tabs/control/systemProtocol.htm.orig
@@ -43,10 +43,10 @@ ResetGAC();
 
 <table class="tTable filterTable" id="SysProtoList" cellspacing="0" cellpadding="0" style="display:none">
   <colgroup>
-    <col style="width:12%;"/>
-    <col style="width:12%;"/>
-    <col style="width:16%;"/>
-    <col style="width:60%;"/>
+    <col />
+    <col />
+    <col />
+    <col />
   </colgroup>
   <thead id="histlistheader">
       <tr>

--- a/buildroot-external/patches/occu/0199-WebUI-ImprovedSystemProtocol/occu/WebUI/www/webui/webui.js
+++ b/buildroot-external/patches/occu/0199-WebUI-ImprovedSystemProtocol/occu/WebUI/www/webui/webui.js
@@ -35938,15 +35938,15 @@ getExtendedDescription = function(oChannelDescr)  {
     multiMode = oChannelDescr.multiMode;
   var tmpDev;
 
-  if (typeof channelAddress != "undefined") {
+  if (typeof channelType != "undefined") {
+    chType = channelType;
+  } else if (typeof channelAddress != "undefined") {
     var channel = DeviceList.getChannelByAddress(channelAddress);
     if (channel) {
       chType = channel.channelType;
       channelIsVisible = channel.isVisible;
     }
-  } else if (typeof channelType != "undefined") {
-    chType = channelType;
-  }
+  } 
 
   if (chType == "KEY_TRANSCEIVER") {
     if (deviceType.toLowerCase().indexOf("hmip-asir") != -1) {
@@ -36025,6 +36025,7 @@ getExtendedDescription = function(oChannelDescr)  {
         case "hmip-wgt-a":
         case "hmip-wgtc":
         case "hmip-wgtc-a":
+          if (channel === undefined) { var channel = DeviceList.getChannelByAddress(channelAddress); }
           var channelMode = homematic("Interface.getMetadata", {
             "objectId": channel.id,
             "dataId": "channelMode"
@@ -36145,12 +36146,14 @@ getExtendedDescription = function(oChannelDescr)  {
         typeExt = "_" + multiMode;
       } else {
         if (channelAddress != "undefined") {
-          var chn = DeviceList.getChannelByAddress(channelAddress),
-          chnMode = parseInt(chn.multiMode);
+          var chn = DeviceList.getChannelByAddress(channelAddress);
+          if (typeof chn != "undefined") {
+          var chnMode = parseInt(chn.multiMode);
           if (! isNaN(chnMode)) {
             typeExt = "_" + chnMode;
           } else {
             typeExt = "";
+          }
           }
         } else {
           typeExt = "_1";

--- a/buildroot-external/patches/occu/0199-WebUI-ImprovedSystemProtocol/occu/WebUI/www/webui/webui.js.orig
+++ b/buildroot-external/patches/occu/0199-WebUI-ImprovedSystemProtocol/occu/WebUI/www/webui/webui.js.orig
@@ -35938,15 +35938,15 @@ getExtendedDescription = function(oChannelDescr)  {
     multiMode = oChannelDescr.multiMode;
   var tmpDev;
 
-  if (typeof channelAddress != "undefined") {
+  if (typeof channelType != "undefined") {
+    chType = channelType;
+  } else if (typeof channelAddress != "undefined") {
     var channel = DeviceList.getChannelByAddress(channelAddress);
     if (channel) {
       chType = channel.channelType;
       channelIsVisible = channel.isVisible;
     }
-  } else if (typeof channelType != "undefined") {
-    chType = channelType;
-  }
+  } 
 
   if (chType == "KEY_TRANSCEIVER") {
     if (deviceType.toLowerCase().indexOf("hmip-asir") != -1) {
@@ -36025,6 +36025,7 @@ getExtendedDescription = function(oChannelDescr)  {
         case "hmip-wgt-a":
         case "hmip-wgtc":
         case "hmip-wgtc-a":
+          if (channel === undefined) { var channel = DeviceList.getChannelByAddress(channelAddress); }
           var channelMode = homematic("Interface.getMetadata", {
             "objectId": channel.id,
             "dataId": "channelMode"
@@ -36145,12 +36146,14 @@ getExtendedDescription = function(oChannelDescr)  {
         typeExt = "_" + multiMode;
       } else {
         if (channelAddress != "undefined") {
-          var chn = DeviceList.getChannelByAddress(channelAddress),
-          chnMode = parseInt(chn.multiMode);
+          var chn = DeviceList.getChannelByAddress(channelAddress);
+          if (typeof chn != "undefined") {
+          var chnMode = parseInt(chn.multiMode);
           if (! isNaN(chnMode)) {
             typeExt = "_" + chnMode;
           } else {
             typeExt = "";
+          }
           }
         } else {
           typeExt = "_1";


### PR DESCRIPTION
This change adds the "-L" option to a curl execution in downloadFirmware.tcl which could result in the command not working correctly if the supplied URL might result in a redirection in future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP redirect handling for version checking
  * Improved DOM rendering and browser compatibility (IE/Firefox)
  * Corrected device parameter update inconsistencies

* **New Features**
  * Added color picker support
  * Enhanced time and date field validation
  * Support for additional device types

* **Improvements**
  * Reorganized System Protocol table layout for better usability
  * Refined event handling and UI responsiveness
  * Enhanced parameter validation across device management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->