### PR TITLE
disable UAS on RPI for JMicron JMS583Gen 2 to PCIe Gen3x2 Bridge

### DIFF
--- a/buildroot-external/board/rpi0/boot.cmd
+++ b/buildroot-external/board/rpi0/boot.cmd
@@ -10,7 +10,7 @@ setenv gpio_button "GPIO24"
 setenv kernel_img /zImage
 setenv kernel_bootcmd bootz
 setenv recoveryfs_initrd "recoveryfs-initrd"
-setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
+setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u,152d:a578:u,152d:0583:u"
 
 # output where we are booting from
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"

--- a/buildroot-external/board/rpi2/boot.cmd
+++ b/buildroot-external/board/rpi2/boot.cmd
@@ -10,7 +10,7 @@ setenv gpio_button "GPIO12"
 setenv kernel_img /zImage
 setenv kernel_bootcmd bootz
 setenv recoveryfs_initrd "recoveryfs-initrd"
-setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
+setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u,152d:a578:u,152d:0583:u"
 
 # output where we are booting from
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"

--- a/buildroot-external/board/rpi3/boot.cmd
+++ b/buildroot-external/board/rpi3/boot.cmd
@@ -10,7 +10,7 @@ setenv gpio_button "GPIO12"
 setenv kernel_img /Image
 setenv kernel_bootcmd booti
 setenv recoveryfs_initrd "recoveryfs-initrd"
-setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
+setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u,152d:a578:u,152d:0583:u"
 
 # output where we are booting from
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"

--- a/buildroot-external/board/rpi4/boot.cmd
+++ b/buildroot-external/board/rpi4/boot.cmd
@@ -10,7 +10,7 @@ setenv gpio_button "GPIO12"
 setenv kernel_img /Image
 setenv kernel_bootcmd booti
 setenv recoveryfs_initrd "recoveryfs-initrd"
-setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
+setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u,152d:a578:u,152d:0583:u"
 
 # output where we are booting from
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"

--- a/buildroot-external/board/rpi5/boot.cmd
+++ b/buildroot-external/board/rpi5/boot.cmd
@@ -10,7 +10,7 @@ setenv gpio_button "GPIO12"
 setenv kernel_img /Image
 setenv kernel_bootcmd booti
 setenv recoveryfs_initrd "recoveryfs-initrd"
-setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
+setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u,152d:a578:u,152d:0583:u"
 
 # output where we are booting from
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"


### PR DESCRIPTION
This change adds more usb-storage.quirk entries to disable UAS for certain more adapters to get these USB adapters working (e.g. JMicron JMS583Gen 2 to PCIe Gen3x2 Bridge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated USB storage device compatibility across Raspberry Pi boot configurations (models 0, 2, 3, 4, and 5) to recognize two additional USB storage device IDs (152d:a578:u and 152d:0583:u) during system startup, improving out-of-the-box support for those devices without changing other boot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->