### PR TITLE
enable Pressure Stall Information (PSI)

### DIFF
--- a/buildroot-external/kernel/6.12/global.config
+++ b/buildroot-external/kernel/6.12/global.config
@@ -100,6 +100,9 @@ CONFIG_PREEMPT=y
 # CONFIG_DEBUG_PREEMPT is not set
 # CONFIG_PREEMPT_DYNAMIC is not set
 
+# support for pressure stall information (PSI)
+CONFIG_PSI=y
+
 # support for /proc/config.gz
 CONFIG_IKCONFIG=y
 CONFIG_IKCONFIG_PROC=y


### PR DESCRIPTION
This change enables Pressure Stall Information (PSI) in the kernel which identifies and quantifies the disruptions caused by CPU, memory or IO resource shortages and the time impact it has on complex workloads or even entire systems.

https://facebookmicrosites.github.io/psi/docs/overview
https://www.kernel.org/doc/html/latest/accounting/psi.html

This refs https://github.com/home-assistant/operating-system/pull/4279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled kernel pressure stall information (PSI) monitoring support in the system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->