### PR TITLE
add detection of Raspberry Pi Compute Module 5

### DIFF
--- a/buildroot-external/overlay/base/etc/init.d/S01InitHost
+++ b/buildroot-external/overlay/base/etc/init.d/S01InitHost
@@ -60,6 +60,7 @@ identify_host() {
       # identify the RaspberryPi model based on HWMODEL (device tree)
       case "${HWMODEL}" in
         *'Pi 5 Model B'*)         HM_HOST="rpi5" ;; # Raspberry Pi 5 Model B
+        *'Pi Compute Module 5'*)  HM_HOST="rpi5" ;; # Raspberry Pi Compute Module 5
         *'Pi 4 Model B'*)         HM_HOST="rpi4" ;; # Raspberry Pi 4 Model B
         *'Pi Compute Module 4'*)  HM_HOST="rpi4" ;; # Raspberry Pi Compute Module 4
         *'Pi 400'*)               HM_HOST="rpi4" ;; # Raspberry Pi 400

--- a/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/S01InitHost
+++ b/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/S01InitHost
@@ -61,6 +61,7 @@ identify_host() {
       # identify the RaspberryPi model based on HWMODEL (device tree)
       case "${HWMODEL}" in
         *'Pi 5 Model B'*)         HM_HOST="rpi5" ;; # Raspberry Pi 5 Model B
+        *'Pi Compute Module 5'*)  HM_HOST="rpi5" ;; # Raspberry Pi Compute Module 5		
         *'Pi 4 Model B'*)         HM_HOST="rpi4" ;; # Raspberry Pi 4 Model B
         *'Pi Compute Module 4'*)  HM_HOST="rpi4" ;; # Raspberry Pi Compute Module 4
         *'Pi 400'*)               HM_HOST="rpi4" ;; # Raspberry Pi 400


### PR DESCRIPTION
Add's the detection of Raspberry Pi Compute Module 5, otherwise the system falls back to (default) rpi3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Raspberry Pi Compute Module 5. The system now properly identifies and configures this device variant, ensuring consistent functionality with other supported Raspberry Pi models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->