### PR TITLE
Invert ACT_LED on Pi5 and CM5

### DIFF
--- a/buildroot-external/board/rpi5/config.txt
+++ b/buildroot-external/board/rpi5/config.txt
@@ -48,6 +48,13 @@ dtparam=watchdog=on
 # start with heartbeat on PWR led and mmc0 on ACT led
 dtparam=pwr_led_trigger=timer,act_led_trigger=mmc0
 
+# special device tree options for Raspberry Pi 5 and Compute Module 5
+[pi5]
+dtparam=act_led_activelow=off
+
+# reset to apply to all platforms
+[all]
+
 # add device tree overlay for RPI-RF-MOD
 dtoverlay=rpi-rf-mod
 


### PR DESCRIPTION
Inverts the behavior of the ACT_LED on the Pi5 and CM5 so that the heartbeat behavior is visually identical to the older Raspberry models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Raspberry Pi 5-specific board configuration parameters for enhanced platform support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->