### PR TITLE
fix missing ELV-SH-PTI2 support by using correct HMIPServer.jar

### DIFF
--- a/buildroot-external/package/occu/Makefile
+++ b/buildroot-external/package/occu/Makefile
@@ -186,7 +186,7 @@ ifneq (,$(filter $(OCCU_RF_PROTOCOL), HM_HMIP HMIP))
 	cp -av HMserver/opt/HMServer/HMServer.jar $(TARGET_DIR)/opt/HMServer/
 	cp -av HMserver/opt/HmIP $(TARGET_DIR)/opt/
 	cp -av HMServer-Beta/opt/HmIP/hmip-copro-update.jar $(TARGET_DIR)/opt/HmIP/
-	cp -av HMServer-Beta/opt/HMServer/HMIPServer.jar $(TARGET_DIR)/opt/HMServer/
+	#cp -av HMServer-Beta/opt/HMServer/HMIPServer.jar $(TARGET_DIR)/opt/HMServer/
 	cp -av HMServer-Beta/opt/HMServer/HMServer.jar $(TARGET_DIR)/opt/HMServer/
 endif
 


### PR DESCRIPTION
This PR fixes missing ELV-SH-PTI2 support by using the correct and latest HMIPServer.jar version from the OCCU repository and not the older/obsolete HMIPServer.jar version form the beta subdir. This might also fix some other related issues that have been addressed in newer HMIPServer versions shipped with OCCU 3.85.7. This fixes #3437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled installation of a server component in the build configuration, preventing it from being included in the final package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->