### PR TITLE
Backport to LTS (batch 2026-01-03)

### DIFF
--- a/buildroot-external/package/occu/Makefile
+++ b/buildroot-external/package/occu/Makefile
@@ -186,7 +186,7 @@ ifneq (,$(filter $(OCCU_RF_PROTOCOL), HM_HMIP HMIP))
 	cp -av HMserver/opt/HMServer/HMServer.jar $(TARGET_DIR)/opt/HMServer/
 	cp -av HMserver/opt/HmIP $(TARGET_DIR)/opt/
 	cp -av HMServer-Beta/opt/HmIP/hmip-copro-update.jar $(TARGET_DIR)/opt/HmIP/
-	cp -av HMServer-Beta/opt/HMServer/HMIPServer.jar $(TARGET_DIR)/opt/HMServer/
+	#cp -av HMServer-Beta/opt/HMServer/HMIPServer.jar $(TARGET_DIR)/opt/HMServer/
 	cp -av HMServer-Beta/opt/HMServer/HMServer.jar $(TARGET_DIR)/opt/HMServer/
 endif
 


### PR DESCRIPTION
Batch backport into `LTS`.

Selection criteria:
- Base branch: `master`
- Required labels: `backport:LTS`, `backport-risk:low`

Included PRs:

- #3438 — fix missing ELV-SH-PTI2 support by using correct HMIPServer.jar (https://github.com/OpenCCU/OpenCCU/pull/3438)

Notes:
- Applied via `git cherry-pick -x` to preserve provenance.
- 'Already present' detection uses ancestry and commit-message provenance.
