### PR TITLE
fix recovery boot for ODROID-C2

### DIFF
--- a/buildroot-external/board/odroid-c2/boot.cmd
+++ b/buildroot-external/board/odroid-c2/boot.cmd
@@ -7,20 +7,13 @@ setenv rootfs 2
 setenv userfs 3
 #setenv gpio_button "23" # pin 32 (GPIOY_13)
 setenv gpio_button "disabled"
+setenv kernel_img /Image
+setenv kernel_bootcmd booti
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv overlays ""
 setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 
 echo "Boot script loaded from ${devtype} ${devnum}"
-
-# decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-  setenv kernel_img /Image
-  setenv kernel_bootcmd booti
-else
-  setenv kernel_img /zImage
-  setenv kernel_bootcmd bootz
-fi
 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
@@ -31,9 +24,7 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if Image doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 \
-   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${ramdisk_addr_r} ${recoveryfs_initrd}


### PR DESCRIPTION
This change is fixing the broken ODROID C2 recovery boot which has failed for some of the latest versions because a wrong u-boot boot.cmd syntax was used to check for GPIO button or recoveryMode file checks on userfs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Boot Improvements**
  * Streamlined kernel selection and boot method for ODROID-C2
  * Enhanced recovery mode with improved environment configuration
  * Optimized recovery condition detection
  * Improved environment variable handling during startup sequence

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->