### PR TITLE
Backport to LTS (batch 2026-01-16)

### DIFF
--- a/.github/workflows/release-lts.yml
+++ b/.github/workflows/release-lts.yml
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJSON(format('[{0}]', (github.event.inputs.platforms == '' || github.event.inputs.platforms == 'all') && '"rpi0","rpi2","rpi3","rpi4","rpi5","tinkerboard","odroid-c2","odroid-c4","odroid-n2","ova","oci_amd64","oci_arm64","oci_arm","generic-x86_64","generic-aarch64","lxc_amd64","lxc_arm64","lxc_arm"' || github.event.inputs.platforms)) }}
+        platform: ${{ fromJSON(format('[{0}]', github.event.inputs.platforms)) }}
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Batch backport into `LTS`.

Selection criteria:
- Base branch: `master`
- Required labels: `backport:LTS`, `backport-risk:low`

Included PRs:

- #3466 — fix lts workflow (https://github.com/OpenCCU/OpenCCU/pull/3466)

Notes:
- Applied via `git cherry-pick -x` to preserve provenance.
- 'Already present' detection uses ancestry and commit-message provenance.
