### PR TITLE
Backport to LTS (batch 2026-01-16)

### DIFF
--- a/.github/workflows/release-lts.yml
+++ b/.github/workflows/release-lts.yml
@@ -16,11 +16,6 @@ on:
         required: true
         type: 'boolean'
         default: 'false'
-      platforms:
-        description: 'List of platforms to build (comma seperated, e.g. "rpi3","rpi4")'
-        required: true
-        default: 'rpi3'
-        type: string
 
 # default read-only permission
 permissions:
@@ -109,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJSON(format('[{0}]', github.event.inputs.platforms)) }}
+        platform: [rpi3] # rpi3/ccu3 only
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Batch backport into `LTS`.

Selection criteria:
- Base branch: `master`
- Required labels: `backport:LTS`, `backport-risk:low`

Included PRs:

- #3468 — fix lts workflow run to rpi3/ccu3 only. (https://github.com/OpenCCU/OpenCCU/pull/3468)

Notes:
- Applied via `git cherry-pick -x` to preserve provenance.
- 'Already present' detection uses ancestry and commit-message provenance.
