### PR TITLE
fix lts release workflow to use OpenCCU-LTS naming.

### DIFF
--- a/.github/workflows/release-lts.yml
+++ b/.github/workflows/release-lts.yml
@@ -173,8 +173,8 @@ jobs:
         with:
           name: OpenCCU-LTS-${{ needs.release_draft.outputs.version }}-${{ matrix.platform }}
           path: |
-            release/OpenCCU-${{ needs.release_draft.outputs.version }}-${{ matrix.platform }}.zip
-            release/OpenCCU-${{ needs.release_draft.outputs.version }}-ccu3.tgz
+            release/OpenCCU-LTS-${{ needs.release_draft.outputs.version }}-${{ matrix.platform }}.zip
+            release/OpenCCU-LTS-${{ needs.release_draft.outputs.version }}-ccu3.tgz
 
       - name: Attest build archive artifact provenance
         uses: actions/attest-build-provenance@v3
@@ -187,7 +187,7 @@ jobs:
         id: upload-manifest
         uses: actions/upload-artifact@v6
         with:
-          path: release/OpenCCU-${{ needs.release_draft.outputs.version }}-${{ matrix.platform }}.mf
+          path: release/OpenCCU-LTS-${{ needs.release_draft.outputs.version }}-${{ matrix.platform }}.mf
           name: OpenCCU-LTS-${{ needs.release_draft.outputs.version }}-${{ matrix.platform }}.mf
 
       - name: Attest manifest artifact provenance


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to standardize LTS artifact naming across all distribution formats, including ZIP packages, compressed archives, and manifest files. This ensures consistent LTS designation throughout all release artifacts, providing clearer identification of LTS releases and improving user experience when downloading and managing Long Term Support versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->