### PR TITLE
Backport to LTS (batch 2026-01-16)

### DIFF
--- a/.github/workflows/release-lts.yml
+++ b/.github/workflows/release-lts.yml
@@ -173,8 +173,8 @@ jobs:
         with:
           name: OpenCCU-LTS-${{ needs.release_draft.outputs.version }}-${{ matrix.platform }}
           path: |
-            release/OpenCCU-${{ needs.release_draft.outputs.version }}-${{ matrix.platform }}.zip
-            release/OpenCCU-${{ needs.release_draft.outputs.version }}-ccu3.tgz
+            release/OpenCCU-LTS-${{ needs.release_draft.outputs.version }}-${{ matrix.platform }}.zip
+            release/OpenCCU-LTS-${{ needs.release_draft.outputs.version }}-ccu3.tgz
 
       - name: Attest build archive artifact provenance
         uses: actions/attest-build-provenance@v3
@@ -187,7 +187,7 @@ jobs:
         id: upload-manifest
         uses: actions/upload-artifact@v6
         with:
-          path: release/OpenCCU-${{ needs.release_draft.outputs.version }}-${{ matrix.platform }}.mf
+          path: release/OpenCCU-LTS-${{ needs.release_draft.outputs.version }}-${{ matrix.platform }}.mf
           name: OpenCCU-LTS-${{ needs.release_draft.outputs.version }}-${{ matrix.platform }}.mf
 
       - name: Attest manifest artifact provenance


### PR DESCRIPTION
Batch backport into `LTS`.

Selection criteria:
- Base branch: `master`
- Required labels: `backport:LTS`, `backport-risk:low`

Included PRs:

- #3471 — fix lts release workflow to use OpenCCU-LTS naming. (https://github.com/OpenCCU/OpenCCU/pull/3471)

Skipped (already present in LTS):

- #3438 — fix missing ELV-SH-PTI2 support by using correct HMIPServer.jar (https://github.com/OpenCCU/OpenCCU/pull/3438)
- #3457 — update OCCU to 3.85.7-2 fixing hs485d issues (https://github.com/OpenCCU/OpenCCU/pull/3457)
- #3464 — add first initial release-lts.yml build workflow (https://github.com/OpenCCU/OpenCCU/pull/3464)
- #3466 — fix lts workflow (https://github.com/OpenCCU/OpenCCU/pull/3466)
- #3468 — fix lts workflow run to rpi3/ccu3 only. (https://github.com/OpenCCU/OpenCCU/pull/3468)

Notes:
- Applied via `git cherry-pick -x` to preserve provenance.
- 'Already present' detection uses ancestry and commit-message provenance.
