### PR TITLE
update CHANGELOG.md to mention HAos 17.0+ requirement

### DIFF
--- a/home-assistant-addon/CHANGELOG.md
+++ b/home-assistant-addon/CHANGELOG.md
@@ -1,5 +1,22 @@
-# ChangeLog
+> **☕ Please Support OpenCCU !**
+>
+> If you find OpenCCU useful, consider supporting its further development:
+>
+> [![GitHub Sponsors](https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg)](https://github.com/sponsors/jens-maus)
+> [![Donate](https://img.shields.io/badge/donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL)
+>
+> Your support helps to constantly maintain and further improve OpenCCU. Thank you! 🙏
+
+---
+
+# What's Changed
+
+> [!IMPORTANT]
+> **🧪 Home Assistant OS 17.0+ required**
+>
+> This OpenCCU HA-Addon version requires at least Home Assistant OS version 17.0 or newer to be installed to work properly! So if you update
+> to this OpenCCU version please ensure that you have your Home Assistant OS version updated accordingly.
 
 For a recent ChangeLog please review the following information:
 
-- [OpenCCU Releases](https://github.com/OpenCCU/OpenCCU/releases)
+- [OpenCCU Commits](https://github.com/OpenCCU/OpenCCU/commits/master)


### PR DESCRIPTION
This updates the CHANGELOG.md in the productive HA-addon directory to ensure HomeAssistantOS 17.0+ dependency is mentioned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog format with additional informational banners and support messaging.
  * Updated reference link for changelog information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->