### PR TITLE
fix error return upon switching firewall settings

### DIFF
--- a/buildroot-external/overlay/base/lib/libfirewall.tcl
+++ b/buildroot-external/overlay/base/lib/libfirewall.tcl
@@ -376,6 +376,15 @@ proc FirewallInternal::Firewall_configureFirewallMostOpen { } {
 
   # user defined ports (the only reason to do this is to enable the user to override settings for services)
   foreach userport $Firewall_USER_PORTS {
+    set userport [string trim $userport]
+    if { $userport eq "" } {
+      continue
+    }
+    if { ![string is integer -strict $userport] || $userport < 1 || $userport > 65535 } {
+      exec logger -t firewall -p user.err "invalid user port '$userport' specified"
+      continue
+    }
+
     try_exec_cmd "/usr/sbin/iptables -A INPUT -p tcp --dport $userport -j ACCEPT"
     try_exec_cmd "/usr/sbin/iptables -A INPUT -p udp --dport $userport -j ACCEPT"
     if { $has_ip6tables } {
@@ -394,6 +403,10 @@ proc FirewallInternal::Firewall_configureFirewallMostOpen { } {
           set prot udp
         }
         foreach ip $Firewall_IPS {
+          set ip [string trim $ip]
+          if { $ip eq "" } {
+            continue
+          }
           if { [regexp {:} $ip] } then {
             try_exec_cmd "/usr/sbin/ip6tables -A INPUT -p $prot --dport $port -s $ip -j ACCEPT"
           } else {
@@ -501,6 +514,15 @@ proc FirewallInternal::Firewall_configureFirewallRestrictive { } {
 
   # user defined ports
   foreach userport $Firewall_USER_PORTS {
+    set userport [string trim $userport]
+    if { $userport eq "" } {
+      continue
+    }
+    if { ![string is integer -strict $userport] || $userport < 1 || $userport > 65535 } {
+      exec logger -t firewall -p user.err "invalid user port '$userport' specified"
+      continue
+    }
+
     try_exec_cmd "/usr/sbin/iptables -A INPUT -p tcp --dport $userport -m state --state NEW -j ACCEPT"
     try_exec_cmd "/usr/sbin/iptables -A INPUT -p udp --dport $userport -j ACCEPT"
     if { $has_ip6tables } {
@@ -522,8 +544,12 @@ proc FirewallInternal::Firewall_configureFirewallRestrictive { } {
             set options ""
         }
         foreach ip $Firewall_IPS {
+          set ip [string trim $ip]
+          if { $ip eq "" } {
+            continue
+          }
           if { [ FirewallInternal::IsIPV4 $ip ] == 1 } then {
-          try_exec_cmd "/usr/sbin/iptables -A INPUT -p $prot --dport $port -s $ip $options -j ACCEPT"
+            try_exec_cmd "/usr/sbin/iptables -A INPUT -p $prot --dport $port -s $ip $options -j ACCEPT"
           } elseif { $has_ip6tables } {
             try_exec_cmd "/usr/sbin/ip6tables -A INPUT -p $prot --dport $port -s $ip $options -j ACCEPT"
           }


### PR DESCRIPTION
This change fixes error messages output to the syslog in case the firewall settings are changed and no user ip or dedicated port numbers are configured. This fixes #3502.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced validation and sanitization of firewall configuration inputs to prevent invalid rules from being applied.
* Port and IP address entries are now trimmed and validated; empty values are skipped, and ports outside the valid range (1–65535) are logged and ignored.
* Improved overall reliability of firewall rule application across IPv4 and IPv6 configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->