### PR TITLE
add some detailed update warning to ha-addon CHANGELOG

### DIFF
--- a/home-assistant-addon-dev/CHANGELOG.md
+++ b/home-assistant-addon-dev/CHANGELOG.md
@@ -15,6 +15,7 @@
 > **`HmIP-RFUSB-TK` issues**
 >
 > If you are using a `HmIP-RFUSB-TK` (with `-TK` in the product name) to communicate with your HomematicIP devices, please make sure to update to Home Assistant OS [17.1rc1](https://github.com/home-assistant/operating-system/releases/tag/17.1.rc1) or newer first, because only with 17.1 or newer full compatibility with `HmIP-RFUSB-TK` is restored!
+
 > [!IMPORTANT]
 > **🧪 Home Assistant OS 17.x required**
 >

--- a/home-assistant-addon/CHANGELOG.md
+++ b/home-assistant-addon/CHANGELOG.md
@@ -15,6 +15,7 @@
 > **`HmIP-RFUSB-TK` issues**
 >
 > If you are using a `HmIP-RFUSB-TK` (with `-TK` in the product name) to communicate with your HomematicIP devices, please make sure to update to Home Assistant OS [17.1rc1](https://github.com/home-assistant/operating-system/releases/tag/17.1.rc1) or newer first, because only with 17.1 or newer full compatibility with `HmIP-RFUSB-TK` is restored!
+
 > [!IMPORTANT]
 > **🧪 Home Assistant OS 17.x required**
 >


### PR DESCRIPTION
This adds a dedicated update warning setion to the CHANGELOG.md of the HA-Addon installation changelog about the HmIP-RFUSB-TK issues requiring a HomeAssistant OS 17.1 update (refs #3498).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added HmIP-RFUSB-TK compatibility warning and related notes.
  * Updated Home Assistant OS version requirement specification to 17.x and newer with updated reference documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->