### PR TITLE
install-lxc.sh/install-proxmox.sh: add RaspberryPiOS Trixie compatibility

### DIFF
--- a/scripts/install-lxc.sh
+++ b/scripts/install-lxc.sh
@@ -22,7 +22,7 @@ trap die ERR
 trap cleanup EXIT
 
 # Set default variables
-VERSION="1.20"
+VERSION="1.21"
 LOGFILE="/tmp/install-lxc.log"
 LINE=
 

--- a/scripts/install-proxmox.sh
+++ b/scripts/install-proxmox.sh
@@ -24,7 +24,7 @@ trap die ERR
 trap cleanup EXIT
 
 # Set default variables
-VERSION="3.18"
+VERSION="3.19"
 LOGFILE="/tmp/install-proxmox.log"
 LINE=
 
@@ -117,7 +117,7 @@ uninstall() {
        grep -q Raspberry /proc/cpuinfo; then
     # arm based RaspberryPiOS system
     info "Identified arm64-based RaspberryPiOS Proxmox VE system..."
-    HEADER_PKGS="raspberrypi-kernel-headers"
+    HEADER_PKGS="linux-headers-rpi-v8"
   elif [[ "${PLATFORM}" == "x86_64" ]]; then
     # full amd64/x86 based Proxmox VE system
     info "Identified x86-based Proxmox VE system..."
@@ -535,7 +535,7 @@ EOF
        grep -q Raspberry /proc/cpuinfo; then
     # arm based RaspberryPiOS system
     info "Identified arm64-based RaspberryPiOS Proxmox VE system..."
-    HEADER_PKGS="raspberrypi-kernel-headers"
+    HEADER_PKGS="linux-headers-rpi-v8"
   elif [[ "${PLATFORM}" == "x86_64" ]]; then
     # full amd64/x86 based Proxmox VE system
     info "Identified x86-based Proxmox VE system..."


### PR DESCRIPTION
Since Raspi-OS "Trixie" the Kernel-Header Package ist renamed to `linux-headers-rpi-v8`.

Older Raspi-OS "Bookworm" seems to support both names, `raspberrypi-kernel-headers` and `linux-headers-rpi-v8`.
So it should stay backward compatible.

Refs: #3473  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Raspberry Pi OS kernel header handling so installs and removals select the most compatible header package per detected platform (arm aarch64, other ARM, x86_64).
  * Updated informational messages to report detected platform and chosen header package.
  * Bumped install scripts: LXC script to 1.21 and Proxmox script to 3.19.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->