### PR TITLE
bump OCCU to 3.87.2-1

### DIFF
--- a/buildroot-external/package/occu/occu.hash
+++ b/buildroot-external/package/occu/occu.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  e600b8a501a17600d01bd7a4646508f94f3cd3b9df03661babd9f1801e579b36  LicenseDE.txt
-sha256  6b7015cf087aeaa0b876e889dd8a58283f1265db2237b7e2912ee2c3c3fe0a5d  occu-3.87.1-1.tar.gz
+sha256  aa1f8beec644468c398eef8d9bc9403c9b972a86cfcf03408abd2956da045133  occu-3.87.2-1.tar.gz

--- a/buildroot-external/package/occu/occu.mk
+++ b/buildroot-external/package/occu/occu.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OCCU_VERSION = 3.87.1-1
+OCCU_VERSION = 3.87.2-1
 OCCU_SITE = $(call github,OpenCCU,occu,$(OCCU_VERSION))
 OCCU_LICENSE = HMSL
 OCCU_LICENSE_FILES = LicenseDE.txt


### PR DESCRIPTION
This updated the used OCCU base to 3.87.2-1 incorporating the latest changes performed by eQ-3 on the base of the OCCU environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated occu package to version 3.87.2-1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->