### PR TITLE
implement rootfs resize functionality in recoveryfs

### DIFF
--- a/buildroot-external/package/recovery-system/external/overlay/base/bin/fwinstall.sh
+++ b/buildroot-external/package/recovery-system/external/overlay/base/bin/fwinstall.sh
@@ -268,6 +268,7 @@ EOF
     NEW_USER_OFFSET=$((NEW_USER_START * SECTOR_SIZE))
     sync
     e2image -ra -p -o "${OLD_USER_OFFSET}" -O "${NEW_USER_OFFSET}" "${DISK_DEV}" || { echo "ERROR: (e2image move userfs)"; return 1; }
+    sync
   else
     echo -ne "userfs already aligned, "
   fi


### PR DESCRIPTION
This change adds functionality to the fwinstall.sh skript being executed as part of the firmware update functionality in the recoveryfs. It now allows to expand or shrink the rootfs to the target size of the supplied update image. In fact, in case of expanding the rootfs, the userfs filesystem and partition will now be moved via e2image to the right and resized accordingly. In case of shrinkage, however, the rootfs partition will just be reduced so that firmware updates using previous versions of the recoveryfs will still work correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic root filesystem resizing during firmware install — supports growing or shrinking, can move/realign the user partition, runs filesystem checks/resize tools, and may resize prior to unpacking with conditional re-unpack.

* **Bug Fixes / Improvements**
  * Byte-accurate partition sizing via block-level queries.
  * Stronger device/partition validation, tighter alignment/space checks, and standardized “ERROR:” messages.
  * Expanded progress/status/warning feedback during install.

* **Chores**
  * Temporary directory reliably cleaned/recreated; clearer installer messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->