### PR TITLE
bump rpi-eeprom to 2026-02-23

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  8070f30d450f10fa9253e7a254cd3877fa4b973eb437b94d8c03e2fabc64c916  LICENSE
-sha256  dd73464e3efdf189edddc9d2136befd6282d6aa7ca2eb965f671a9b6ce4499c1  rpi-eeprom-d9e44d8bb3b05b8e5f9f58e28fc95f1c909e924f.tar.gz
+sha256  f68e3bf83cd3de9e24ec9740763960791e20103096f6809b8e5cd0588bcf7db4  rpi-eeprom-a34ba1bcc4f46a2f4c7f3b1e806a238fdacd3698.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = d9e44d8bb3b05b8e5f9f58e28fc95f1c909e924f
+RPI_EEPROM_VERSION = a34ba1bcc4f46a2f4c7f3b1e806a238fdacd3698
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause
 RPI_EEPROM_LICENSE_FILES = LICENSE
@@ -12,10 +12,10 @@ RPI_EEPROM_INSTALL_IMAGES = YES
 
 ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI4),y)
   # Raspberry Pi 4 (2711)
-  RPI_EEPROM_FIRMWARE_PATH = firmware-2711/stable/pieeprom-2026-02-06.bin
+  RPI_EEPROM_FIRMWARE_PATH = firmware-2711/stable/pieeprom-2026-02-23.bin
 else ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI5),y)
   # Raspberry Pi 5 (2712)
-  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-02-06.bin
+  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-02-23.bin
 endif
 
 define RPI_EEPROM_BUILD_CMDS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Raspberry Pi EEPROM firmware to the latest stable versions for both Raspberry Pi 4 and Raspberry Pi 5. Firmware builds are now dated 2026-02-23, updated from previous 2026-02-06 builds. Updated package version and checksums to match the new firmware versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->