### PR TITLE
bump OCCU to 3.87.6-1

### DIFF
--- a/buildroot-external/package/occu/occu.hash
+++ b/buildroot-external/package/occu/occu.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  e600b8a501a17600d01bd7a4646508f94f3cd3b9df03661babd9f1801e579b36  LicenseDE.txt
-sha256  ba178e9a6dc6aa8e33777851c610e689f385c426d7edbf01aec4f9893bf53085  occu-3.87.4-1.tar.gz
+sha256  9951dce2c6d5e78ce9a2c514bb42db88c715813f319f5aacb3aa650b98b8eec4  occu-3.87.6-1.tar.gz

--- a/buildroot-external/package/occu/occu.mk
+++ b/buildroot-external/package/occu/occu.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OCCU_VERSION = 3.87.4-1
+OCCU_VERSION = 3.87.6-1
 OCCU_SITE = $(call github,OpenCCU,occu,$(OCCU_VERSION))
 OCCU_LICENSE = HMSL
 OCCU_LICENSE_FILES = LicenseDE.txt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated occu package to version 3.87.6-1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->