### PR TITLE
move "NoCronBackup - Check" from cronbackup.sh to crontab.root

### DIFF
--- a/buildroot-external/overlay/base-openccu/bin/cronBackup.sh
+++ b/buildroot-external/overlay/base-openccu/bin/cronBackup.sh
@@ -30,9 +30,6 @@
 #   a file /etc/config/CronBackupMaxBackups
 #
 
-# skip the script if /etc/config/NoCronBackup exists
-[[ -e /etc/config/NoCronBackup ]] && exit 0
-
 # read in /var/hm_mode
 [[ -r /var/hm_mode ]] && . /var/hm_mode
 

--- a/buildroot-external/overlay/base-openccu/etc/crontab.root
+++ b/buildroot-external/overlay/base-openccu/etc/crontab.root
@@ -1,7 +1,7 @@
 1 3,9,15,21 * * * [ ! -e /usr/local/HMLGW ] && /bin/SetInterfaceClock
 */15 * * * * /usr/sbin/logrotate /etc/logrotate.conf || logger -p error -t "logrotate" "logrotate aborted with error $?"
 */1 * * * * /bin/updateDCVars.tcl >/dev/null 2>/dev/null
-7 0 * * * /bin/nice /bin/cronBackup.sh >/dev/null 2>/dev/null
+7 0 * * * [ ! -e /etc/config/NoCronBackup ] && /bin/nice /bin/cronBackup.sh >/dev/null 2>/dev/null
 0 4 * * 6 [ ! -e /etc/config/NoFSTRIM ] && /bin/nice /sbin/fstrim --listed-in /etc/fstab:/proc/self/mountinfo --verbose --quiet-unsupported | logger -p info -t fstrim
 59 1 * * * [ ! -e /etc/config/NoBadBlocksCheck ] && /bin/nice /bin/checkBadBlocks.sh >/dev/null 2>/dev/null
 */10 * * * * [ -d /media/usb0/measurement ] && /bin/nice /usr/bin/rsync -aogX --delete-after --no-whole-file --checksum /tmp/measurement/ /media/usb0/measurement/ >/dev/null 2>/dev/null

--- a/buildroot-external/overlay/base-openccu_lxc/etc/crontab.root
+++ b/buildroot-external/overlay/base-openccu_lxc/etc/crontab.root
@@ -1,6 +1,6 @@
 1 3,9,15,21 * * * /bin/SetInterfaceClock
 */15 * * * * /usr/sbin/logrotate /etc/logrotate.conf || logger -p error -t "logrotate" "logrotate aborted with error $?"
 */1 * * * * /bin/updateDCVars.tcl >/dev/null 2>/dev/null
-7 0 * * * /bin/nice /bin/cronBackup.sh >/dev/null 2>/dev/null
+7 0 * * * [ ! -e /etc/config/NoCronBackup ] && /bin/nice /bin/cronBackup.sh >/dev/null 2>/dev/null
 */10 * * * * [ -d /media/usb0/measurement ] && /bin/nice /usr/bin/rsync -aogX --delete-after --no-whole-file --checksum /tmp/measurement/ /media/usb0/measurement/ >/dev/null 2>/dev/null
 0 12 * * * sleep $((RANDOM % 900))s && /bin/checkAddonUpdates.sh >/dev/null 2>/dev/null

--- a/buildroot-external/overlay/base-openccu_oci/etc/crontab.root
+++ b/buildroot-external/overlay/base-openccu_oci/etc/crontab.root
@@ -1,7 +1,7 @@
 1 3,9,15,21 * * * [ ! -e /usr/local/HMLGW ] && /bin/SetInterfaceClock
 */15 * * * * /usr/sbin/logrotate /etc/logrotate.conf || logger -p error -t "logrotate" "logrotate aborted with error $?"
 */1 * * * * /bin/updateDCVars.tcl >/dev/null 2>/dev/null
-7 0 * * * /bin/nice /bin/cronBackup.sh >/dev/null 2>/dev/null
+7 0 * * * [ ! -e /etc/config/NoCronBackup ] && /bin/nice /bin/cronBackup.sh >/dev/null 2>/dev/null
 */10 * * * * [ -d /media/usb0/measurement ] && /bin/nice /usr/bin/rsync -aogX --delete-after --no-whole-file --checksum /tmp/measurement/ /media/usb0/measurement/ >/dev/null 2>/dev/null
 0 12 * * * [ ! -e /etc/config/NoAddonUpdateCheck ] && sleep $((RANDOM % 900))s && /bin/checkAddonUpdates.sh >/dev/null 2>/dev/null
 0 4 * * 0 [ ! -e /etc/config/NoPortForwardingCheck ] && sleep $((RANDOM % 900))s && /bin/checkPortForwarding.sh >/dev/null 2>/dev/null


### PR DESCRIPTION
- removes the "NoCronBackup - Check" from cronBackup.sh
- adds the "NoCronBackup - Check" to crontab.root

This moves the NoCronBackup check from the cronBackup.sh script to crontab.root.
This standardizes the use of NoXXX files and prevents the script from being called by the cron job if the NoCronBackup file exists.
In addition, the user can then call cronBackup.sh for testing purposes, for example, even if the NoCronBackup file is present.

Refs:
partly: https://github.com/orgs/OpenCCU/discussions/3580#discussioncomment-15964311
partly: https://homematic-forum.de/forum/viewtopic.php?f=65&t=87700#p855073

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized backup scheduling control logic for improved management.

* **New Features**
  * Added periodic consistency verification for supported system variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->