### PR TITLE
move changelog header to EULA files and just generate changelog in workflow actions.

### DIFF
--- a/.github/workflows/release-lts.yml
+++ b/.github/workflows/release-lts.yml
@@ -85,7 +85,7 @@ jobs:
           export PREVIOUS_TAG=${{ steps.previoustag.outputs.tag }}
           envsubst <.github/release-template.md >/tmp/release-template.md
 
-      - name: Generate EULA release summary
+      - name: Generate ChangeLog summary
         shell: bash
         run: |
           CHANGE_ITEMS=$(cat <<'EOF' | sed -n 's/^[[:space:]]*[-*][[:space:]]\+//p' | sed 's/@Copilot/@jens-maus/g'
@@ -93,27 +93,21 @@ jobs:
           EOF
           )
 
-          mkdir -p /tmp/eula-release-summary
+          mkdir -p /tmp/changelog-summary
 
           generate_summary() {
             local lang="$1"
             local outfile="$2"
-            local header_link label_changes label_fallback
+            local label_fallback
             case "${lang}" in
               de)
-                header_link='<p><b>Zum aktuellen ChangeLog und zur Release-&Uuml;bersicht besuchen Sie:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>'
-                label_changes='<p><b>&Auml;nderungen in dieser Version im Vergleich zur vorherigen Version:</b></p>'
                 label_fallback='Siehe Release-Seite f&uuml;r den vollst&auml;ndigen Changelog.'
                 ;;
               *)
-                header_link='<p><b>For recent ChangeLog and Releases overview visit:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>'
-                label_changes='<p><b>Changes in this release compared to the previous version:</b></p>'
                 label_fallback='See release page for the full changelog.'
                 ;;
             esac
             {
-              echo "${header_link}"
-              echo "${label_changes}"
               echo '<ul>'
               if [[ -n "${CHANGE_ITEMS}" ]]; then
                 printf '%s\n' "${CHANGE_ITEMS}" | python3 -c "import html,sys; [print('<li>' + html.escape(line.strip(), quote=True).encode('ascii', 'xmlcharrefreplace').decode('ascii') + '</li>') for line in sys.stdin if line.strip()]"
@@ -125,8 +119,8 @@ jobs:
             } >"${outfile}"
           }
 
-          generate_summary en /tmp/eula-release-summary/eula-release-summary.en.html
-          generate_summary de /tmp/eula-release-summary/eula-release-summary.de.html
+          generate_summary en /tmp/changelog-summary/changelog-summary.en.html
+          generate_summary de /tmp/changelog-summary/changelog-summary.de.html
 
       - name: Upload release-template.md artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
@@ -134,11 +128,11 @@ jobs:
           path: /tmp/release-template.md
           name: release-template.md
 
-      - name: Upload EULA release summary artifact
+      - name: Upload ChangeLog summary artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
         with:
-          path: /tmp/eula-release-summary/
-          name: eula-release-summary
+          path: /tmp/changelog-summary/
+          name: changelog-summary
 
   build:
     permissions:
@@ -198,32 +192,32 @@ jobs:
           fi
           echo "build_datetime=$(date -u +'%FT%T.%3NZ')" >> $GITHUB_OUTPUT
 
-      - name: Download EULA release summary artifact
+      - name: Download ChangeLog summary artifact
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8
         with:
-          name: eula-release-summary
-          path: /tmp/eula-release-summary
+          name: changelog-summary
+          path: /tmp/changelog-summary
 
-      - name: Inject release summary into EULA files
+      - name: Inject ChangeLog into EULA files
         shell: bash
         run: |
           python3 - <<'PY'
           from pathlib import Path
 
-          summary_dir = Path("/tmp/eula-release-summary")
-          begin_marker = b"<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->"
-          end_marker   = b"<!-- OPENCCU_RELEASE_SUMMARY_END -->"
+          summary_dir = Path("/tmp/changelog-summary")
+          begin_marker = b"<!-- OPENCCU_CHANGELOG_BEGIN -->"
+          end_marker   = b"<!-- OPENCCU_CHANGELOG_END -->"
 
           def get_fragment(eula_path: Path) -> bytes:
               """Return the locale-appropriate summary fragment, falling back to English."""
               # EULA.de, EULA.de_nightly → locale "de"; EULA.en, EULA.en_nightly → locale "en"
               suffix = eula_path.name.split(".", 1)[1] if "." in eula_path.name else "en"
               locale = suffix.split("_")[0]
-              locale_file = summary_dir / f"eula-release-summary.{locale}.html"
+              locale_file = summary_dir / f"changelog-summary.{locale}.html"
               if locale_file.exists():
                   return locale_file.read_bytes()
               # Fallback to English
-              return (summary_dir / "eula-release-summary.en.html").read_bytes()
+              return (summary_dir / "changelog-summary.en.html").read_bytes()
 
           for eula in Path("release/updatepkg").glob("*/EULA.*"):
             content = eula.read_bytes()
@@ -239,7 +233,7 @@ jobs:
               marker = b"</body>"
               if marker not in content:
                 raise RuntimeError(
-                  f"Could not find OPENCCU_RELEASE_SUMMARY markers or </body> in {eula}"
+                  f"Could not find OPENCCU_CHANGELOG markers or </body> in {eula}"
                 )
               section = begin_marker + b"\n" + fragment + b"\n" + end_marker
               eula.write_bytes(content.replace(marker, section + b"\n" + marker, 1))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           export PREVIOUS_TAG=${{ steps.previoustag.outputs.tag }}
           envsubst <.github/release-template.md >/tmp/release-template.md
 
-      - name: Generate EULA release summary
+      - name: Generate ChangeLog summary
         shell: bash
         run: |
           CHANGE_ITEMS=$(cat <<'EOF' | sed -n 's/^[[:space:]]*[-*][[:space:]]\+//p' | sed 's/@Copilot/@jens-maus/g'
@@ -97,27 +97,21 @@ jobs:
           EOF
           )
 
-          mkdir -p /tmp/eula-release-summary
+          mkdir -p /tmp/changelog-summary
 
           generate_summary() {
             local lang="$1"
             local outfile="$2"
-            local header_link label_changes label_fallback
+            local label_fallback
             case "${lang}" in
               de)
-                header_link='<p><b>Zum aktuellen ChangeLog und zur Release-&Uuml;bersicht besuchen Sie:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>'
-                label_changes='<p><b>&Auml;nderungen in dieser Version im Vergleich zur vorherigen Version:</b></p>'
                 label_fallback='Siehe Release-Seite f&uuml;r den vollst&auml;ndigen Changelog.'
                 ;;
               *)
-                header_link='<p><b>For recent ChangeLog and Releases overview visit:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>'
-                label_changes='<p><b>Changes in this release compared to the previous version:</b></p>'
                 label_fallback='See release page for the full changelog.'
                 ;;
             esac
             {
-              echo "${header_link}"
-              echo "${label_changes}"
               echo '<ul>'
               if [[ -n "${CHANGE_ITEMS}" ]]; then
                 printf '%s\n' "${CHANGE_ITEMS}" | python3 -c "import html,sys; [print('<li>' + html.escape(line.strip(), quote=True).encode('ascii', 'xmlcharrefreplace').decode('ascii') + '</li>') for line in sys.stdin if line.strip()]"
@@ -129,8 +123,8 @@ jobs:
             } >"${outfile}"
           }
 
-          generate_summary en /tmp/eula-release-summary/eula-release-summary.en.html
-          generate_summary de /tmp/eula-release-summary/eula-release-summary.de.html
+          generate_summary en /tmp/changelog-summary/changelog-summary.en.html
+          generate_summary de /tmp/changelog-summary/changelog-summary.de.html
 
       - name: Create release draft
         id: release_drafter
@@ -150,11 +144,11 @@ jobs:
           path: /tmp/release-template.md
           name: release-template.md
 
-      - name: Upload EULA release summary artifact
+      - name: Upload ChangeLog summary artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
         with:
-          path: /tmp/eula-release-summary/
-          name: eula-release-summary
+          path: /tmp/changelog-summary/
+          name: changelog-summary
 
   build:
     permissions:
@@ -214,32 +208,32 @@ jobs:
           fi
           echo "build_datetime=$(date -u +'%FT%T.%3NZ')" >> $GITHUB_OUTPUT
 
-      - name: Download EULA release summary artifact
+      - name: Download ChangeLog summary artifact
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8
         with:
-          name: eula-release-summary
-          path: /tmp/eula-release-summary
+          name: changelog-summary
+          path: /tmp/changelog-summary
 
-      - name: Inject release summary into EULA files
+      - name: Inject ChangeLog summary into EULA files
         shell: bash
         run: |
           python3 - <<'PY'
           from pathlib import Path
 
-          summary_dir = Path("/tmp/eula-release-summary")
-          begin_marker = b"<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->"
-          end_marker   = b"<!-- OPENCCU_RELEASE_SUMMARY_END -->"
+          summary_dir = Path("/tmp/changelog-summary")
+          begin_marker = b"<!-- OPENCCU_CHANGELOG_BEGIN -->"
+          end_marker   = b"<!-- OPENCCU_CHANGELOG_END -->"
 
           def get_fragment(eula_path: Path) -> bytes:
               """Return the locale-appropriate summary fragment, falling back to English."""
               # EULA.de, EULA.de_nightly → locale "de"; EULA.en, EULA.en_nightly → locale "en"
               suffix = eula_path.name.split(".", 1)[1] if "." in eula_path.name else "en"
               locale = suffix.split("_")[0]
-              locale_file = summary_dir / f"eula-release-summary.{locale}.html"
+              locale_file = summary_dir / f"changelog-summary.{locale}.html"
               if locale_file.exists():
                   return locale_file.read_bytes()
               # Fallback to English
-              return (summary_dir / "eula-release-summary.en.html").read_bytes()
+              return (summary_dir / "changelog-summary.en.html").read_bytes()
 
           for eula in Path("release/updatepkg").glob("*/EULA.*"):
             content = eula.read_bytes()
@@ -255,7 +249,7 @@ jobs:
               marker = b"</body>"
               if marker not in content:
                 raise RuntimeError(
-                  f"Could not find OPENCCU_RELEASE_SUMMARY markers or </body> in {eula}"
+                  f"Could not find OPENCCU_CHANGELOG markers or </body> in {eula}"
                 )
               section = begin_marker + b"\n" + fragment + b"\n" + end_marker
               eula.write_bytes(content.replace(marker, section + b"\n" + marker, 1))

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -34,11 +34,11 @@ jobs:
     outputs:
       has-commits: ${{ steps.commit-check.outputs.has-commits }}
 
-  eula_summary:
+  changelog_summary:
     permissions:
       contents: read
       pull-requests: read  # mikepenz/release-changelog-builder-action
-    name: Generate EULA release summary
+    name: Generate ChangeLog summary
     if: ${{ github.repository == 'OpenCCU/OpenCCU' && (github.event_name != 'schedule' || needs.repo-check.outputs.has-commits > 0) }}
     runs-on: ubuntu-24.04
     needs: repo-check
@@ -62,7 +62,7 @@ jobs:
           fromTag: ${{ steps.previoustag.outputs.tag }}
           toTag: ${{ github.sha }}
 
-      - name: Generate EULA release summary
+      - name: Generate ChangeLog summary
         shell: bash
         run: |
           CHANGE_ITEMS=$(cat <<'EOF' | sed -n 's/^[[:space:]]*[-*][[:space:]]\+//p' | sed 's/@Copilot/@jens-maus/g'
@@ -70,7 +70,7 @@ jobs:
           EOF
           )
 
-          mkdir -p /tmp/eula-release-summary
+          mkdir -p /tmp/changelog-summary
 
           generate_summary() {
             local lang="$1"
@@ -102,14 +102,14 @@ jobs:
             } >"${outfile}"
           }
 
-          generate_summary en /tmp/eula-release-summary/eula-release-summary.en.html
-          generate_summary de /tmp/eula-release-summary/eula-release-summary.de.html
+          generate_summary en /tmp/changelog-summary/changelog-summary.en.html
+          generate_summary de /tmp/changelog-summary/changelog-summary.de.html
 
-      - name: Upload EULA release summary artifact
+      - name: Upload ChangeLog summary artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
         with:
-          path: /tmp/eula-release-summary/
-          name: eula-release-summary
+          path: /tmp/changelog-summary/
+          name: changelog-summary
 
   build:
     permissions:
@@ -119,7 +119,7 @@ jobs:
     name: Snapshot build [${{ matrix.platform }}]
     if: ${{ github.repository == 'OpenCCU/OpenCCU' && (github.event_name != 'schedule' || needs.repo-check.outputs.has-commits > 0) }}
     runs-on: self-hosted
-    needs: [repo-check, eula_summary]
+    needs: [repo-check, changelog_summary]
     timeout-minutes: 300
     outputs:
       build_datetime: ${{ steps.env.outputs.build_datetime }}
@@ -180,32 +180,32 @@ jobs:
           mv -f release/updatepkg/${{ matrix.platform }}/EULA.de_nightly release/updatepkg/${{ matrix.platform }}/EULA.de
           mv -f release/updatepkg/${{ matrix.platform }}/EULA.en_nightly release/updatepkg/${{ matrix.platform }}/EULA.en
 
-      - name: Download EULA release summary artifact
+      - name: Download ChangeLog summary artifact
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8
         with:
-          name: eula-release-summary
-          path: /tmp/eula-release-summary
+          name: changelog-summary
+          path: /tmp/changelog-summary
 
-      - name: Inject release summary into EULA files
+      - name: Inject ChangeLog summary into EULA files
         shell: bash
         run: |
           python3 - <<'PY'
           from pathlib import Path
 
-          summary_dir = Path("/tmp/eula-release-summary")
-          begin_marker = b"<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->"
-          end_marker   = b"<!-- OPENCCU_RELEASE_SUMMARY_END -->"
+          summary_dir = Path("/tmp/changelog-summary")
+          begin_marker = b"<!-- OPENCCU_CHANGELOG_BEGIN -->"
+          end_marker   = b"<!-- OPENCCU_CHANGELOG_END -->"
 
           def get_fragment(eula_path: Path) -> bytes:
               """Return the locale-appropriate summary fragment, falling back to English."""
               # EULA.de, EULA.de_nightly → locale "de"; EULA.en, EULA.en_nightly → locale "en"
               suffix = eula_path.name.split(".", 1)[1] if "." in eula_path.name else "en"
               locale = suffix.split("_")[0]
-              locale_file = summary_dir / f"eula-release-summary.{locale}.html"
+              locale_file = summary_dir / f"changelog-summary.{locale}.html"
               if locale_file.exists():
                   return locale_file.read_bytes()
               # Fallback to English
-              return (summary_dir / "eula-release-summary.en.html").read_bytes()
+              return (summary_dir / "changelog-summary.en.html").read_bytes()
 
           for eula in Path("release/updatepkg").glob("*/EULA.*"):
             content = eula.read_bytes()
@@ -221,7 +221,7 @@ jobs:
               marker = b"</body>"
               if marker not in content:
                 raise RuntimeError(
-                  f"Could not find OPENCCU_RELEASE_SUMMARY markers or </body> in {eula}"
+                  f"Could not find OPENCCU_CHANGELOG markers or </body> in {eula}"
                 )
               section = begin_marker + b"\n" + fragment + b"\n" + end_marker
               eula.write_bytes(content.replace(marker, section + b"\n" + marker, 1))

--- a/release/updatepkg/lxc_arm64/EULA.de
+++ b/release/updatepkg/lxc_arm64/EULA.de
@@ -8,8 +8,6 @@
 <p><a href="https://github.com/sponsors/jens-maus"><img src="https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg" alt="GitHub Sponsors"/></a>
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL"><img src="https://img.shields.io/badge/donate-PayPal-green.svg" alt="Spenden via PayPal"/></a></p>
 <p>Ihre Unterst&uuml;tzung hilft OpenCCU kontinuierlich zu pflegen und weiter zu verbessern. Vielen Dank!</p>
-<p>Aktuelle OpenCCU-Releases finden Sie hier:<br/>
-<a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a></p>
 <hr/>
 <p>Sie sind dabei auf Ihrem CCU System eine Drittanbieterfirmware namens
 <a href=https://openccu.de/>OpenCCU</a> zu installieren.
@@ -24,8 +22,10 @@ dieses Firmware-Update Ihre s&auml;mtlichen Einstellungen &uuml;bernommen. Wir
 raten Ihnen jedoch trotzdem dazu ein separates Backup vor dem Update auf
 diese Firmware durchzuf&uuml;hren und an einem sicheren Ort aufzubewahren.</p>
 <hr/>
-<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->
-<!-- OPENCCU_RELEASE_SUMMARY_END -->
+<p><b>Zum aktuellen ChangeLog und zur Release-&Uuml;bersicht besuchen Sie:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>
+<p><b>&Auml;nderungen in dieser Version im Vergleich zur vorherigen Version:</b></p>
+<!-- OPENCCU_CHANGELOG_BEGIN -->
+<!-- OPENCCU_CHANGELOG_END -->
 <p>Bei der "OpenCCU" Software/Firmware handelt es sich um ein freies,
 nicht-kommerzielles Open Source Projekt (<a href=https://openccu.de/>https://openccu.de/</a>)
 das selbst unter der <a href=https://www.apache.org/licenses/LICENSE-2.0>Apache 2.0 Lizenz</a>

--- a/release/updatepkg/lxc_arm64/EULA.de_nightly
+++ b/release/updatepkg/lxc_arm64/EULA.de_nightly
@@ -8,8 +8,6 @@
 <p><a href="https://github.com/sponsors/jens-maus"><img src="https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg" alt="GitHub Sponsors"/></a>
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL"><img src="https://img.shields.io/badge/donate-PayPal-green.svg" alt="Spenden via PayPal"/></a></p>
 <p>Ihre Unterst&uuml;tzung hilft OpenCCU kontinuierlich zu pflegen und weiter zu verbessern. Vielen Dank!</p>
-<p>Aktuelle OpenCCU-Releases finden Sie hier:<br/>
-<a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a></p>
 <hr/>
 <p><font color="red">Sie sind dabei eine experimentelle Version von
 OpenCCU auf ihrer CCU zu installieren. Bei der Nutzung dieser
@@ -35,8 +33,10 @@ dieses Firmware-Update Ihre s&auml;mtlichen Einstellungen &uuml;bernommen. Wir
 raten Ihnen jedoch trotzdem dazu ein separates Backup vor dem Update auf
 diese Firmware durchzuf&uuml;hren und an einem sicheren Ort aufzubewahren.</p>
 <hr/>
-<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->
-<!-- OPENCCU_RELEASE_SUMMARY_END -->
+<p><b>Zum aktuellen ChangeLog und zur Release-&Uuml;bersicht besuchen Sie:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>
+<p><b>&Auml;nderungen in dieser Version im Vergleich zur vorherigen Version:</b></p>
+<!-- OPENCCU_CHANGELOG_BEGIN -->
+<!-- OPENCCU_CHANGELOG_END -->
 <p>Bei der "OpenCCU" Software/Firmware handelt es sich um ein freies,
 nicht-kommerzielles Open Source Projekt (<a href=https://openccu.de/>https://openccu.de/</a>)
 das selbst unter der <a href=https://www.apache.org/licenses/LICENSE-2.0>Apache 2.0 Lizenz</a>

--- a/release/updatepkg/lxc_arm64/EULA.en
+++ b/release/updatepkg/lxc_arm64/EULA.en
@@ -8,8 +8,6 @@
 <p><a href="https://github.com/sponsors/jens-maus"><img src="https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg" alt="GitHub Sponsors"/></a>
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL"><img src="https://img.shields.io/badge/donate-PayPal-green.svg" alt="Donate via PayPal"/></a></p>
 <p>Your support helps to constantly maintain and further improve OpenCCU. Thank you!</p>
-<p>Recent OpenCCU releases are available here:<br/>
-<a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a></p>
 <hr/>
 <p>You are about to install a third-party firmware on your CCU device.
 This <a href=https://openccu.de/>OpenCCU</a> firmware
@@ -24,8 +22,10 @@ converted to be usable with the OpenCCU firmware. We do,
 however, suggest that you create a fresh backup before actually
 installing this firmware on your CCU device.</p>
 <hr/>
-<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->
-<!-- OPENCCU_RELEASE_SUMMARY_END -->
+<p><b>For recent ChangeLog and Releases overview visit:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>
+<p><b>Changes in this release compared to the previous version:</b></p>
+<!-- OPENCCU_CHANGELOG_BEGIN -->
+<!-- OPENCCU_CHANGELOG_END -->
 <p>The "OpenCCU" software/firmware is a free and non-commercial
 open source software project (<a href=https://openccu.de/>https://openccu.de/</a>)
 which is distributed under the terms and conditions of the

--- a/release/updatepkg/lxc_arm64/EULA.en_nightly
+++ b/release/updatepkg/lxc_arm64/EULA.en_nightly
@@ -8,10 +8,7 @@
 <p><a href="https://github.com/sponsors/jens-maus"><img src="https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg" alt="GitHub Sponsors"/></a>
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL"><img src="https://img.shields.io/badge/donate-PayPal-green.svg" alt="Donate via PayPal"/></a></p>
 <p>Your support helps to constantly maintain and further improve OpenCCU. Thank you!</p>
-<p>Recent OpenCCU releases are available here:<br/>
-<a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a></p>
 <hr/>
-
 <p><font color="red">You are about to install an experimental version
 of OpenCCU on your CCU device! Using such experimental versions
 could impose severe issues that might cause your configuration to
@@ -36,8 +33,10 @@ converted to be usable with the OpenCCU firmware. We do,
 however, suggest that you create a fresh backup before actually
 installing this firmware on your CCU device.</p>
 <hr/>
-<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->
-<!-- OPENCCU_RELEASE_SUMMARY_END -->
+<p><b>For recent ChangeLog and Releases overview visit:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>
+<p><b>Changes in this release compared to the previous version:</b></p>
+<!-- OPENCCU_CHANGELOG_BEGIN -->
+<!-- OPENCCU_CHANGELOG_END -->
 <p>The "OpenCCU" software/firmware is a free and non-commercial
 open source software project (<a href=https://openccu.de/>https://openccu.de/</a>)
 which is distributed under the terms and conditions of the

--- a/release/updatepkg/oci_arm64/EULA.de
+++ b/release/updatepkg/oci_arm64/EULA.de
@@ -8,8 +8,6 @@
 <p><a href="https://github.com/sponsors/jens-maus"><img src="https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg" alt="GitHub Sponsors"/></a>
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL"><img src="https://img.shields.io/badge/donate-PayPal-green.svg" alt="Spenden via PayPal"/></a></p>
 <p>Ihre Unterst&uuml;tzung hilft OpenCCU kontinuierlich zu pflegen und weiter zu verbessern. Vielen Dank!</p>
-<p>Aktuelle OpenCCU-Releases finden Sie hier:<br/>
-<a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a></p>
 <hr/>
 <p>Sie sind dabei auf Ihrem CCU System eine Drittanbieterfirmware namens
 <a href=https://openccu.de/>OpenCCU</a> zu installieren.
@@ -24,8 +22,10 @@ dieses Firmware-Update Ihre s&auml;mtlichen Einstellungen &uuml;bernommen. Wir
 raten Ihnen jedoch trotzdem dazu ein separates Backup vor dem Update auf
 diese Firmware durchzuf&uuml;hren und an einem sicheren Ort aufzubewahren.</p>
 <hr/>
-<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->
-<!-- OPENCCU_RELEASE_SUMMARY_END -->
+<p><b>Zum aktuellen ChangeLog und zur Release-&Uuml;bersicht besuchen Sie:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>
+<p><b>&Auml;nderungen in dieser Version im Vergleich zur vorherigen Version:</b></p>
+<!-- OPENCCU_CHANGELOG_BEGIN -->
+<!-- OPENCCU_CHANGELOG_END -->
 <p>Bei der "OpenCCU" Software/Firmware handelt es sich um ein freies,
 nicht-kommerzielles Open Source Projekt (<a href=https://openccu.de/>https://openccu.de/</a>)
 das selbst unter der <a href=https://www.apache.org/licenses/LICENSE-2.0>Apache 2.0 Lizenz</a>

--- a/release/updatepkg/oci_arm64/EULA.de_nightly
+++ b/release/updatepkg/oci_arm64/EULA.de_nightly
@@ -8,8 +8,6 @@
 <p><a href="https://github.com/sponsors/jens-maus"><img src="https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg" alt="GitHub Sponsors"/></a>
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL"><img src="https://img.shields.io/badge/donate-PayPal-green.svg" alt="Spenden via PayPal"/></a></p>
 <p>Ihre Unterst&uuml;tzung hilft OpenCCU kontinuierlich zu pflegen und weiter zu verbessern. Vielen Dank!</p>
-<p>Aktuelle OpenCCU-Releases finden Sie hier:<br/>
-<a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a></p>
 <hr/>
 <p><font color="red">Sie sind dabei eine experimentelle Version von
 OpenCCU auf ihrer CCU zu installieren. Bei der Nutzung dieser
@@ -35,8 +33,10 @@ dieses Firmware-Update Ihre s&auml;mtlichen Einstellungen &uuml;bernommen. Wir
 raten Ihnen jedoch trotzdem dazu ein separates Backup vor dem Update auf
 diese Firmware durchzuf&uuml;hren und an einem sicheren Ort aufzubewahren.</p>
 <hr/>
-<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->
-<!-- OPENCCU_RELEASE_SUMMARY_END -->
+<p><b>Zum aktuellen ChangeLog und zur Release-&Uuml;bersicht besuchen Sie:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>
+<p><b>&Auml;nderungen in dieser Version im Vergleich zur vorherigen Version:</b></p>
+<!-- OPENCCU_CHANGELOG_BEGIN -->
+<!-- OPENCCU_CHANGELOG_END -->
 <p>Bei der "OpenCCU" Software/Firmware handelt es sich um ein freies,
 nicht-kommerzielles Open Source Projekt (<a href=https://openccu.de/>https://openccu.de/</a>)
 das selbst unter der <a href=https://www.apache.org/licenses/LICENSE-2.0>Apache 2.0 Lizenz</a>

--- a/release/updatepkg/oci_arm64/EULA.en
+++ b/release/updatepkg/oci_arm64/EULA.en
@@ -8,8 +8,6 @@
 <p><a href="https://github.com/sponsors/jens-maus"><img src="https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg" alt="GitHub Sponsors"/></a>
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL"><img src="https://img.shields.io/badge/donate-PayPal-green.svg" alt="Donate via PayPal"/></a></p>
 <p>Your support helps to constantly maintain and further improve OpenCCU. Thank you!</p>
-<p>Recent OpenCCU releases are available here:<br/>
-<a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a></p>
 <hr/>
 <p>You are about to install a third-party firmware on your CCU device.
 This <a href=https://openccu.de/>OpenCCU</a> firmware
@@ -24,8 +22,10 @@ converted to be usable with the OpenCCU firmware. We do,
 however, suggest that you create a fresh backup before actually
 installing this firmware on your CCU device.</p>
 <hr/>
-<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->
-<!-- OPENCCU_RELEASE_SUMMARY_END -->
+<p><b>For recent ChangeLog and Releases overview visit:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>
+<p><b>Changes in this release compared to the previous version:</b></p>
+<!-- OPENCCU_CHANGELOG_BEGIN -->
+<!-- OPENCCU_CHANGELOG_END -->
 <p>The "OpenCCU" software/firmware is a free and non-commercial
 open source software project (<a href=https://openccu.de/>https://openccu.de/</a>)
 which is distributed under the terms and conditions of the

--- a/release/updatepkg/oci_arm64/EULA.en_nightly
+++ b/release/updatepkg/oci_arm64/EULA.en_nightly
@@ -8,10 +8,7 @@
 <p><a href="https://github.com/sponsors/jens-maus"><img src="https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg" alt="GitHub Sponsors"/></a>
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL"><img src="https://img.shields.io/badge/donate-PayPal-green.svg" alt="Donate via PayPal"/></a></p>
 <p>Your support helps to constantly maintain and further improve OpenCCU. Thank you!</p>
-<p>Recent OpenCCU releases are available here:<br/>
-<a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a></p>
 <hr/>
-
 <p><font color="red">You are about to install an experimental version
 of OpenCCU on your CCU device! Using such experimental versions
 could impose severe issues that might cause your configuration to
@@ -36,8 +33,10 @@ converted to be usable with the OpenCCU firmware. We do,
 however, suggest that you create a fresh backup before actually
 installing this firmware on your CCU device.</p>
 <hr/>
-<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->
-<!-- OPENCCU_RELEASE_SUMMARY_END -->
+<p><b>For recent ChangeLog and Releases overview visit:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>
+<p><b>Changes in this release compared to the previous version:</b></p>
+<!-- OPENCCU_CHANGELOG_BEGIN -->
+<!-- OPENCCU_CHANGELOG_END -->
 <p>The "OpenCCU" software/firmware is a free and non-commercial
 open source software project (<a href=https://openccu.de/>https://openccu.de/</a>)
 which is distributed under the terms and conditions of the

--- a/release/updatepkg/rpi3/EULA.de
+++ b/release/updatepkg/rpi3/EULA.de
@@ -8,8 +8,6 @@
 <p><a href="https://github.com/sponsors/jens-maus"><img src="https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg" alt="GitHub Sponsors"/></a>
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL"><img src="https://img.shields.io/badge/donate-PayPal-green.svg" alt="Spenden via PayPal"/></a></p>
 <p>Ihre Unterst&uuml;tzung hilft OpenCCU kontinuierlich zu pflegen und weiter zu verbessern. Vielen Dank!</p>
-<p>Aktuelle OpenCCU-Releases finden Sie hier:<br/>
-<a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a></p>
 <hr/>
 <p>Sie sind dabei auf Ihrem CCU System eine Drittanbieterfirmware namens
 <a href=https://openccu.de/>OpenCCU</a> zu installieren.
@@ -24,8 +22,10 @@ dieses Firmware-Update Ihre s&auml;mtlichen Einstellungen &uuml;bernommen. Wir
 raten Ihnen jedoch trotzdem dazu ein separates Backup vor dem Update auf
 diese Firmware durchzuf&uuml;hren und an einem sicheren Ort aufzubewahren.</p>
 <hr/>
-<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->
-<!-- OPENCCU_RELEASE_SUMMARY_END -->
+<p><b>Zum aktuellen ChangeLog und zur Release-&Uuml;bersicht besuchen Sie:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>
+<p><b>&Auml;nderungen in dieser Version im Vergleich zur vorherigen Version:</b></p>
+<!-- OPENCCU_CHANGELOG_BEGIN -->
+<!-- OPENCCU_CHANGELOG_END -->
 <p>Bei der "OpenCCU" Software/Firmware handelt es sich um ein freies,
 nicht-kommerzielles Open Source Projekt (<a href=https://openccu.de/>https://openccu.de/</a>)
 das selbst unter der <a href=https://www.apache.org/licenses/LICENSE-2.0>Apache 2.0 Lizenz</a>

--- a/release/updatepkg/rpi3/EULA.de_nightly
+++ b/release/updatepkg/rpi3/EULA.de_nightly
@@ -8,8 +8,6 @@
 <p><a href="https://github.com/sponsors/jens-maus"><img src="https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg" alt="GitHub Sponsors"/></a>
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL"><img src="https://img.shields.io/badge/donate-PayPal-green.svg" alt="Spenden via PayPal"/></a></p>
 <p>Ihre Unterst&uuml;tzung hilft OpenCCU kontinuierlich zu pflegen und weiter zu verbessern. Vielen Dank!</p>
-<p>Aktuelle OpenCCU-Releases finden Sie hier:<br/>
-<a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a></p>
 <hr/>
 <p><font color="red">Sie sind dabei eine experimentelle Version von
 OpenCCU auf ihrer CCU zu installieren. Bei der Nutzung dieser
@@ -35,8 +33,10 @@ dieses Firmware-Update Ihre s&auml;mtlichen Einstellungen &uuml;bernommen. Wir
 raten Ihnen jedoch trotzdem dazu ein separates Backup vor dem Update auf
 diese Firmware durchzuf&uuml;hren und an einem sicheren Ort aufzubewahren.</p>
 <hr/>
-<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->
-<!-- OPENCCU_RELEASE_SUMMARY_END -->
+<p><b>Zum aktuellen ChangeLog und zur Release-&Uuml;bersicht besuchen Sie:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>
+<p><b>&Auml;nderungen in dieser Version im Vergleich zur vorherigen Version:</b></p>
+<!-- OPENCCU_CHANGELOG_BEGIN -->
+<!-- OPENCCU_CHANGELOG_END -->
 <p>Bei der "OpenCCU" Software/Firmware handelt es sich um ein freies,
 nicht-kommerzielles Open Source Projekt (<a href=https://openccu.de/>https://openccu.de/</a>)
 das selbst unter der <a href=https://www.apache.org/licenses/LICENSE-2.0>Apache 2.0 Lizenz</a>

--- a/release/updatepkg/rpi3/EULA.en
+++ b/release/updatepkg/rpi3/EULA.en
@@ -8,8 +8,6 @@
 <p><a href="https://github.com/sponsors/jens-maus"><img src="https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg" alt="GitHub Sponsors"/></a>
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL"><img src="https://img.shields.io/badge/donate-PayPal-green.svg" alt="Donate via PayPal"/></a></p>
 <p>Your support helps to constantly maintain and further improve OpenCCU. Thank you!</p>
-<p>Recent OpenCCU releases are available here:<br/>
-<a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a></p>
 <hr/>
 <p>You are about to install a third-party firmware on your CCU device.
 This <a href=https://openccu.de/>OpenCCU</a> firmware
@@ -24,8 +22,10 @@ converted to be usable with the OpenCCU firmware. We do,
 however, suggest that you create a fresh backup before actually
 installing this firmware on your CCU device.</p>
 <hr/>
-<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->
-<!-- OPENCCU_RELEASE_SUMMARY_END -->
+<p><b>For recent ChangeLog and Releases overview visit:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>
+<p><b>Changes in this release compared to the previous version:</b></p>
+<!-- OPENCCU_CHANGELOG_BEGIN -->
+<!-- OPENCCU_CHANGELOG_END -->
 <p>The "OpenCCU" software/firmware is a free and non-commercial
 open source software project (<a href=https://openccu.de/>https://openccu.de/</a>)
 which is distributed under the terms and conditions of the

--- a/release/updatepkg/rpi3/EULA.en_nightly
+++ b/release/updatepkg/rpi3/EULA.en_nightly
@@ -8,10 +8,7 @@
 <p><a href="https://github.com/sponsors/jens-maus"><img src="https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink.svg" alt="GitHub Sponsors"/></a>
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL"><img src="https://img.shields.io/badge/donate-PayPal-green.svg" alt="Donate via PayPal"/></a></p>
 <p>Your support helps to constantly maintain and further improve OpenCCU. Thank you!</p>
-<p>Recent OpenCCU releases are available here:<br/>
-<a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a></p>
 <hr/>
-
 <p><font color="red">You are about to install an experimental version
 of OpenCCU on your CCU device! Using such experimental versions
 could impose severe issues that might cause your configuration to
@@ -36,8 +33,10 @@ converted to be usable with the OpenCCU firmware. We do,
 however, suggest that you create a fresh backup before actually
 installing this firmware on your CCU device.</p>
 <hr/>
-<!-- OPENCCU_RELEASE_SUMMARY_BEGIN -->
-<!-- OPENCCU_RELEASE_SUMMARY_END -->
+<p><b>For recent ChangeLog and Releases overview visit:</b> <a href="https://github.com/OpenCCU/OpenCCU/releases">https://github.com/OpenCCU/OpenCCU/releases</a>.</p>
+<p><b>Changes in this release compared to the previous version:</b></p>
+<!-- OPENCCU_CHANGELOG_BEGIN -->
+<!-- OPENCCU_CHANGELOG_END -->
 <p>The "OpenCCU" software/firmware is a free and non-commercial
 open source software project (<a href=https://openccu.de/>https://openccu.de/</a>)
 which is distributed under the terms and conditions of the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured release notes presentation in end-user license agreements to prominently feature changelog sections and links to release information.

* **Chores**
  * Updated release workflows to use a generalized changelog generation system instead of EULA-specific summaries, with improved naming and organizational structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->