### PR TITLE
bump OCCU to 3.87.6-2

### DIFF
--- a/buildroot-external/package/occu/occu.hash
+++ b/buildroot-external/package/occu/occu.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  e600b8a501a17600d01bd7a4646508f94f3cd3b9df03661babd9f1801e579b36  LicenseDE.txt
-sha256  9951dce2c6d5e78ce9a2c514bb42db88c715813f319f5aacb3aa650b98b8eec4  occu-3.87.6-1.tar.gz
+sha256  1aa10984f0297a512f818f57d7d72f37e5f6929377afbb149feecb3247c3e2b2  occu-3.87.6-2.tar.gz

--- a/buildroot-external/package/occu/occu.mk
+++ b/buildroot-external/package/occu/occu.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OCCU_VERSION = 3.87.6-1
+OCCU_VERSION = 3.87.6-2
 OCCU_SITE = $(call github,OpenCCU,occu,$(OCCU_VERSION))
 OCCU_LICENSE = HMSL
 OCCU_LICENSE_FILES = LicenseDE.txt


### PR DESCRIPTION
This bumps the OCCU upstream version to 3.87.6-2 which comes with updated hm-apps, especially with an updated ReGaHss version which potentially might address an issue with showing webui elements twice (refs #1467).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated occu package to version 3.87.6-2 with corresponding verification hash updates to maintain package integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->