### PR TITLE
Backport to LTS (batch 2026-03-26)

### DIFF
--- a/.github/release-changelog-config-lts.json
+++ b/.github/release-changelog-config-lts.json
@@ -1,0 +1,38 @@
+{
+  "categories": [
+    {
+      "title": "#### 🏠 CCU/homematicIP Service Changes",
+      "labels": [":label: OCCU", ":label: HmIPServer", ":label: RFD", ":label: ReGaHss"]
+    },
+    {
+      "title": "#### 🌐 WebUI Changes",
+      "labels": [":label: WebUI"]
+    },
+    {
+      "title": "#### 🖥️ Operating System Changes",
+      "labels": [":label: OS"]
+    },
+    {
+      "title": "#### 🔄 Other Changes",
+      "labels": []
+    }
+  ],
+  "ignore_labels": [
+    "skip-changelog",
+    "dependencies",
+    "github_actions"
+  ],
+  "include_labels": [
+    "backport:LTS"
+  ],
+  "sort": {
+    "order": "DESC",
+    "on_property": "mergedAt"
+  },
+  "template": "${{CHANGELOG}}",
+  "pr_template": "- ${{TITLE}} (#${{NUMBER}}, @${{AUTHOR}})",
+  "empty_template": "- No changes",
+  "label_extractor": [],
+  "max_pull_requests": 1000,
+  "max_back_track_time_days": 365
+}

--- a/.github/release-template-lts.md
+++ b/.github/release-template-lts.md
@@ -1,0 +1,23 @@
+This is release ${VERSION} of OpenCCU-LTS (the LTS variant of [OpenCCU](http://github.com/OpenCCU/OpenCCU)) with the following bugfixes and feature changes:
+
+[![Downloads](https://img.shields.io/github/downloads/homematicip/OpenCCU-LTS/${VERSION}/total.svg?style=flat-square)](https://github.com/homematicip/OpenCCU-LTS/releases/${VERSION}) ![License](https://img.shields.io/github/license/homematicip/OpenCCU-LTS.svg?style=flat-square) [![Donate](https://img.shields.io/badge/donate-PayPal-green.svg?style=flat-square)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL) [![GitHub sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&link=https://github.com/sponsors/jens-maus)](https://github.com/sponsors/jens-maus)
+
+## 🚧 Changes:
+<sub>For all changes, see the [full commit log](https://github.com/homematicip/OpenCCU-LTS/compare/${PREVIOUS_TAG}...${VERSION}).</sub>
+
+${CHANGELOG}
+
+## 📝 Support:
+For support on installation and help please visit the following web pages:
+
+[OpenCCU - Documentation :us:](https://github.com/OpenCCU/OpenCCU/wiki/en.Home)
+[OpenCCU - Discussions :us:](https://github.com/OpenCCU/OpenCCU/discussions)
+[OpenCCU - Dokumentation :de:](https://github.com/OpenCCU/OpenCCU/wiki)
+[OpenCCU - Forum :de:](https://homematic-forum.de/forum/viewforum.php?f=65)
+
+## 📦 Download:
+The following installation archives can be downloaded for different hardware platforms. To verify their integrity a `sha256` checksum is provided as well. You can either upload these files using the WebUI-based update mechanism or unarchive them to e.g. flash the included `*.img` files on a fresh installation media (e.g. microSD card):
+
+- [CCU3](https://github.com/OpenCCU/OpenCCU/wiki/Installation-CCU3), [ELV-Charly](https://github.com/OpenCCU/OpenCCU/wiki/Installation-ELV-Charly), RaspberryPi3 Model B+, RaspberryPi3 Model B, RaspberryPi3 Model A+, RaspberryPi Compute Module 3, RaspberryPi Compute Module 3 lite, RaspberryPi Zero 2 W – ([installation](https://github.com/OpenCCU/OpenCCU/wiki/Installation-CCU3)):
+<sub>📦 [OpenCCU-LTS-${VERSION}-ccu3.tgz](https://github.com/homematicip/OpenCCU-LTS/releases/download/${VERSION}/OpenCCU-LTS-${VERSION}-ccu3.tgz) **(only for initial CCU3 Firmware -> OpenCCU-LTS Upgrade)**<br/> SHA256: XSHAccu3.tgzX</sub>
+<sub>📦 [OpenCCU-LTS-${VERSION}-rpi3.zip](https://github.com/homematicip/OpenCCU-LTS/releases/download/${VERSION}/OpenCCU-LTS-${VERSION}-rpi3.zip)<br/>SHA256: XSHArpi3.zipX</sub>

--- a/.github/workflows/release-lts.yml
+++ b/.github/workflows/release-lts.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
         default: 'YYYYMMDD'
+      previous_tag:
+        description: 'Previous LTS version tag (3.X.Y.YYYYMMDD)'
+        required: true
+        type: string
       test_workflow:
         description: 'Test workflow (dry-run)?'
         required: true
@@ -61,17 +65,13 @@ jobs:
             echo "tag=${OCCU_VERSION}.${BUILD_DATE}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Get previous tag
-        id: previoustag
-        uses: WyriHaximus/github-action-get-previous-tag@61819f33034117e6c686e6a31dba995a85afc9de  # v2.0
-
       - name: Generate changelog
         id: changelog
         uses: mikepenz/release-changelog-builder-action@a34a8009a9588bb86b02a873cf592440e96a5da8  # v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          configuration: ".github/release-changelog-config.json"
-          fromTag: ${{ steps.previoustag.outputs.tag }}
+          configuration: ".github/release-changelog-config-lts.json"
+          fromTag: ${{ github.event.inputs.previous_tag }}
           toTag: ${{ github.sha }}
 
       - name: Generate release notes
@@ -82,8 +82,8 @@ jobs:
           EOF
           )"
           export VERSION=${{ steps.env.outputs.version }}
-          export PREVIOUS_TAG=${{ steps.previoustag.outputs.tag }}
-          envsubst <.github/release-template.md >/tmp/release-template.md
+          export PREVIOUS_TAG=${{ github.event.inputs.previous_tag }}
+          envsubst <.github/release-template-lts.md >/tmp/release-template.md
 
       - name: Generate ChangeLog summary
         shell: bash
@@ -150,7 +150,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [rpi3] # rpi3/ccu3 only
+        platform: [rpi3]  # rpi3/ccu3 only
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Batch backport into `LTS`.

Selection criteria:
- Base branch: `master`
- Required labels: `backport:LTS`, `backport-risk:low`

Included PRs:

- #3669 — modify release-lts workflow (https://github.com/OpenCCU/OpenCCU/pull/3669)

Notes:
- Applied via `git cherry-pick -x` to preserve provenance.
- 'Already present' detection uses ancestry and commit-message provenance.
