### PR TITLE
Backport to LTS (batch 2026-03-26)

### DIFF
--- a/.github/release-changelog-config-lts.json
+++ b/.github/release-changelog-config-lts.json
@@ -22,13 +22,13 @@
     "dependencies",
     "github_actions"
   ],
-  "include_labels": [
-    "backport:LTS"
-  ],
   "sort": {
     "order": "DESC",
     "on_property": "mergedAt"
   },
+  "exclude_merge_branches": [
+    "Backport to LTS (batch"
+  ],
   "template": "${{CHANGELOG}}",
   "pr_template": "- ${{TITLE}} (#${{NUMBER}}, @${{AUTHOR}})",
   "empty_template": "- No changes",


### PR DESCRIPTION
Batch backport into `LTS`.

Selection criteria:
- Base branch: `master`
- Required labels: `backport:LTS`, `backport-risk:low`

Included PRs:

- #3671 — Refine LTS changelog generation to include real PRs and suppress batch-wrapper noise (https://github.com/OpenCCU/OpenCCU/pull/3671)

Skipped (already present in LTS):

- #3669 — modify release-lts workflow (https://github.com/OpenCCU/OpenCCU/pull/3669)

Notes:
- Applied via `git cherry-pick -x` to preserve provenance.
- 'Already present' detection uses ancestry and commit-message provenance.
