### PR TITLE
Backport to LTS (batch 2026-03-26)

### DIFF
--- a/.github/release-changelog-config-lts.json
+++ b/.github/release-changelog-config-lts.json
@@ -27,8 +27,13 @@
     "on_property": "mergedAt"
   },
   "exclude_merge_branches": [
-    "Backport to LTS (batch"
+    "Backport to LTS (batch",
+    "from OpenCCU/backport/batch-lts-"
   ],
+  "duplicate_filter": {
+    "pattern": "\\(#([0-9]+)\\)",
+    "target": "$1"
+  },
   "template": "${{CHANGELOG}}",
   "pr_template": "- ${{TITLE}} (#${{NUMBER}}, @${{AUTHOR}})",
   "empty_template": "- No changes",

--- a/.github/workflows/release-lts.yml
+++ b/.github/workflows/release-lts.yml
@@ -73,6 +73,7 @@ jobs:
           configuration: ".github/release-changelog-config-lts.json"
           fromTag: ${{ github.event.inputs.previous_tag }}
           toTag: ${{ github.sha }}
+          fetchViaCommits: true
 
       - name: Generate release notes
         shell: bash


### PR DESCRIPTION
Batch backport into `LTS`.

Selection criteria:
- Base branch: `master`
- Required labels: `backport:LTS`, `backport-risk:low`

Included PRs:

- #3673 — Make LTS changelog complete for backports and suppress batch-wrapper noise (https://github.com/OpenCCU/OpenCCU/pull/3673)

Skipped (already present in LTS):

- #3669 — modify release-lts workflow (https://github.com/OpenCCU/OpenCCU/pull/3669)
- #3671 — Refine LTS changelog generation to include real PRs and suppress batch-wrapper noise (https://github.com/OpenCCU/OpenCCU/pull/3671)

Notes:
- Applied via `git cherry-pick -x` to preserve provenance.
- 'Already present' detection uses ancestry and commit-message provenance.
