### PR TITLE
Backport to LTS (batch 2026-03-27)

### DIFF
--- a/.github/workflows/release-lts.yml
+++ b/.github/workflows/release-lts.yml
@@ -495,8 +495,8 @@ jobs:
               NEEDLE=${BASENAME#${PREFIX}}
               ESCAPED_NEEDLE=$(printf '%s\n' "${NEEDLE}" | sed -e 's/[][\\/.*^$+?|(){}-]/\\&/g')
               if ! grep -qF "XSHA${NEEDLE}X" release-template.unpatched.md/release-template.md; then
-                echo "Missing checksum placeholder XSHA${NEEDLE}X in release-template artifact" >&2
-                exit 1
+                # Some manifest entries (e.g. *.img) don't have release-template placeholders.
+                continue
               fi
               sed -i "s|XSHA${ESCAPED_NEEDLE}X|${CHECKSUM}|" release-template.unpatched.md/release-template.md
             done < "${f}"


### PR DESCRIPTION
Batch backport into `LTS`.

Selection criteria:
- Base branch: `master`
- Required labels: `backport:LTS`, `backport-risk:low`

Included PRs:

- #3681 — release-lts: tolerate non-template manifest entries during checksum patching (https://github.com/OpenCCU/OpenCCU/pull/3681)

Skipped (already present in LTS):

- #3675 — Harden LTS changelog PR selection by removing unsafe dedup and filtering backport wrapper titles (https://github.com/OpenCCU/OpenCCU/pull/3675)
- #3677 — Rework LTS release changelog generation to exclude backport wrapper PRs (https://github.com/OpenCCU/OpenCCU/pull/3677)
- #3679 — Rework `release-lts.yml` to produce checksum-patched release notes artifact without publishing/updating releases (https://github.com/OpenCCU/OpenCCU/pull/3679)

Notes:
- Applied via `git cherry-pick -x` to preserve provenance.
- 'Already present' detection uses ancestry and commit-message provenance.
