### PR TITLE
fix monitrc using wrong dbus pid

### DIFF
--- a/buildroot-external/overlay/base-openccu/etc/monitrc
+++ b/buildroot-external/overlay/base-openccu/etc/monitrc
@@ -88,7 +88,7 @@ check program irqbalanceEnabled with path /bin/sh -c "/usr/bin/test $(nproc) -gt
     if status != 0 for 1 cycles then unmonitor
 
 # dbus daemon monitoring
-check process dbus with pidfile /run/messagebus.pid
+check process dbus with pidfile /run/dbus-daemon.pid
     group system
     start = "/etc/init.d/S30dbus-daemon start"
     stop = "/etc/init.d/S30dbus-daemon stop"


### PR DESCRIPTION
This change fixes an issue with the latest dbus-daemon init startup script using a different PIDFILE in recent buildroot versions, but our monitrc config still using the old PIDFILE name. This resulted in constant dbus starts being performed by monit while dbus was already correctly started (fixes #3691).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved system process monitoring configuration to ensure accurate service tracking and enhanced system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->