### PR TITLE
fix snapshot workflow change check

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -33,8 +33,8 @@ jobs:
           fetch-depth: 0
       - id: commit-check
         run: |
-          REF=$(git --no-pager log --no-merges --grep='snapshot bump \[' --pretty='format:%H' -1)
-          COUNT=$(git --no-pager log --no-merges --pretty='format:%s' ${REF:+$REF..}HEAD | grep -v -e '\(snapshot\|release\) bump \[' | wc -l)
+          REF=$(git --no-pager log --no-merges --grep='snapshot bump \[' --pretty='tformat:%H' -1)
+          COUNT=$(git --no-pager log --no-merges --pretty='tformat:%s' ${REF:+$REF..}HEAD | grep -v -e '\(snapshot\|release\) bump \[' | wc -l)
           echo "has-commits=$COUNT" >> "$GITHUB_OUTPUT"
     outputs:
       has-commits: ${{ steps.commit-check.outputs.has-commits }}


### PR DESCRIPTION
This change fixes the git log based check for changes which is executed
in advance of the nightly snapshot check. Now it will check for the
latest "snapshot bump" commit title and check if there has been any
changes since then and then only execute a new snapshot build if
relevant changes are found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflow now fetches full git history instead of a shallow clone to enable accurate commit analysis.
  * Improved commit-detection logic used to compute and expose the workflow output flag for whether new commits exist, excluding automated bump commits from the count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->