### PR TITLE
add timeout to cancel install-docker operation after max 300 seconds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,7 +412,7 @@ jobs:
           export CCU_NETWORK_INTERFACE="none"
           export CCU_NETWORK_SUBNET="none"
           sudo mknod /dev/eq3loop c 239 0 # fake /dev/eq3loop
-          #sudo -E timeout 300 bash -x ./scripts/install-docker.sh
+          sudo -E timeout 300 bash -x ./scripts/install-docker.sh || true
 
       - name: Test container startup+stop
         if: github.event.inputs.full_build == 'true'
@@ -446,8 +446,8 @@ jobs:
       - name: Remove/Cleanup container environment
         if: always()
         run: |
-          #sudo -E timeout 300 ./scripts/install-docker.sh uninstall
-          #docker volume rm ccu_data
+          sudo -E timeout 300 ./scripts/install-docker.sh uninstall
+          docker volume rm ccu_data || true
           docker image ls -a
           docker image rm ${{ env.CCU_OCI_REPO }}:${{ env.CCU_OCI_TAG }}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI install step no longer blocks the pipeline if it fails or times out.
  * Cleanup step now runs unconditionally in CI, even after earlier failures.
  * Cleanup retains image listing and removal; volume cleanup and uninstall operations are treated as non-fatal so they won't fail the job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->